### PR TITLE
支持包含多集的资源

### DIFF
--- a/app/android/src/main/kotlin/AndroidModules.kt
+++ b/app/android/src/main/kotlin/AndroidModules.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.serialization.json.Json
 import me.him188.ani.android.navigation.AndroidBrowserNavigator
 import me.him188.ani.app.navigation.BrowserNavigator
+import me.him188.ani.app.platform.currentAniBuildConfig
 import me.him188.ani.app.platform.getAniUserAgent
 import me.him188.ani.app.tools.torrent.DefaultTorrentManager
 import me.him188.ani.app.tools.torrent.TorrentManager
@@ -58,6 +59,7 @@ fun getAndroidModules(
                     config = TorrentDownloaderConfig(
                         peerFingerprint = computeTorrentFingerprint(),
                         userAgent = computeTorrentUserAgent(),
+                        isDebug = currentAniBuildConfig.isDebug,
                     )
                 )
             }

--- a/app/desktop/src/AniDesktop.kt
+++ b/app/desktop/src/AniDesktop.kt
@@ -57,6 +57,7 @@ import me.him188.ani.app.navigation.LocalNavigator
 import me.him188.ani.app.platform.DesktopContext
 import me.him188.ani.app.platform.LocalContext
 import me.him188.ani.app.platform.createAppRootCoroutineScope
+import me.him188.ani.app.platform.currentAniBuildConfig
 import me.him188.ani.app.platform.getAniUserAgent
 import me.him188.ani.app.platform.getCommonKoinModule
 import me.him188.ani.app.platform.startCommonKoinModule
@@ -136,6 +137,7 @@ object AniDesktop {
                                 config = TorrentDownloaderConfig(
                                     peerFingerprint = computeTorrentFingerprint(),
                                     userAgent = computeTorrentUserAgent(),
+                                    isDebug = currentAniBuildConfig.isDebug,
                                 )
                             )
                         }

--- a/app/shared/data/common/data/media/TorrentMediaCacheEngine.kt
+++ b/app/shared/data/common/data/media/TorrentMediaCacheEngine.kt
@@ -26,6 +26,7 @@ import me.him188.ani.datasources.core.cache.MediaCacheEngine
 import me.him188.ani.datasources.core.cache.MediaStats
 import me.him188.ani.utils.coroutines.SuspendLazy
 import kotlin.coroutines.CoroutineContext
+import kotlin.io.path.deleteIfExists
 
 private const val EXTRA_TORRENT_DATA = "torrentData"
 
@@ -100,7 +101,7 @@ class TorrentMediaCacheEngine(
                 if (deleted) return
                 deleted = true
             }
-            file.first().close() // TODO: 删除缓存文件 
+            file.first().entry.resolveFile().deleteIfExists()
         }
     }
 

--- a/app/shared/data/common/data/media/TorrentMediaCacheEngine.kt
+++ b/app/shared/data/common/data/media/TorrentMediaCacheEngine.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.shareIn
 import me.him188.ani.app.data.media.resolver.TorrentVideoSourceResolver
+import me.him188.ani.app.torrent.FilePriority
 import me.him188.ani.app.torrent.TorrentDownloader
 import me.him188.ani.app.torrent.TorrentFileHandle
 import me.him188.ani.app.torrent.model.EncodedTorrentData
@@ -90,7 +91,7 @@ class TorrentMediaCacheEngine(
 
         override suspend fun resume() {
             if (deleted) return
-            file.first().resume()
+            file.first().resume(FilePriority.LOW)
         }
 
         override suspend fun delete() {

--- a/app/shared/data/common/data/media/TorrentMediaCacheEngine.kt
+++ b/app/shared/data/common/data/media/TorrentMediaCacheEngine.kt
@@ -29,6 +29,7 @@ import me.him188.ani.utils.logging.info
 import me.him188.ani.utils.logging.logger
 import kotlin.coroutines.CoroutineContext
 import kotlin.io.path.deleteIfExists
+import kotlin.io.path.exists
 
 private const val EXTRA_TORRENT_DATA = "torrentData"
 
@@ -112,7 +113,12 @@ class TorrentMediaCacheEngine(
             val handle = file.first()
             val file = handle.entry.resolveFile()
             handle.close()
-            file.deleteIfExists()
+            if (file.exists()) {
+                logger.info { "Deleting torrent cache: $file" }
+                file.deleteIfExists()
+            } else {
+                logger.info { "Torrent cache does not exist, ignoring: $file" }
+            }
         }
     }
 

--- a/app/shared/data/common/data/media/resolver/LocalFileVideoSourceResolver.kt
+++ b/app/shared/data/common/data/media/resolver/LocalFileVideoSourceResolver.kt
@@ -2,7 +2,6 @@ package me.him188.ani.app.data.media.resolver
 
 import me.him188.ani.app.videoplayer.data.VideoSource
 import me.him188.ani.app.videoplayer.torrent.FileVideoSource
-import me.him188.ani.datasources.api.EpisodeSort
 import me.him188.ani.datasources.api.Media
 import me.him188.ani.datasources.api.topic.ResourceLocation
 import java.io.File
@@ -12,7 +11,7 @@ class LocalFileVideoSourceResolver : VideoSourceResolver {
         return media.download is ResourceLocation.LocalFile
     }
 
-    override suspend fun resolve(media: Media, episode: EpisodeSort): VideoSource<*> {
+    override suspend fun resolve(media: Media, episode: EpisodeMetadata): VideoSource<*> {
         when (val download = media.download) {
             is ResourceLocation.LocalFile -> {
                 return FileVideoSource(

--- a/app/shared/data/common/data/media/resolver/TorrentVideoSourceResolver.kt
+++ b/app/shared/data/common/data/media/resolver/TorrentVideoSourceResolver.kt
@@ -3,12 +3,21 @@ package me.him188.ani.app.data.media.resolver
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import me.him188.ani.app.tools.torrent.TorrentManager
+import me.him188.ani.app.torrent.FilePriority
+import me.him188.ani.app.torrent.TorrentFileEntry
 import me.him188.ani.app.torrent.model.EncodedTorrentData
+import me.him188.ani.app.videoplayer.data.OpenFailures
 import me.him188.ani.app.videoplayer.data.VideoSource
+import me.him188.ani.app.videoplayer.data.VideoSourceOpenException
 import me.him188.ani.app.videoplayer.torrent.TorrentVideoData
 import me.him188.ani.datasources.api.EpisodeSort
 import me.him188.ani.datasources.api.Media
 import me.him188.ani.datasources.api.topic.ResourceLocation
+import me.him188.ani.datasources.api.topic.contains
+import me.him188.ani.datasources.api.topic.titles.RawTitleParser
+import me.him188.ani.datasources.api.topic.titles.parse
+import me.him188.ani.utils.logging.info
+import me.him188.ani.utils.logging.logger
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
@@ -19,23 +28,68 @@ class TorrentVideoSourceResolver(
         return media.download is ResourceLocation.HttpTorrentFile || media.download is ResourceLocation.MagnetLink
     }
 
-    override suspend fun resolve(media: Media, episode: EpisodeSort): VideoSource<*> {
+    override suspend fun resolve(media: Media, episode: EpisodeMetadata): VideoSource<*> {
         return when (val location = media.download) {
             is ResourceLocation.HttpTorrentFile,
             is ResourceLocation.MagnetLink
             -> {
                 TorrentVideoSource(
-                    torrentManager.downloader.await().fetchTorrent(location.uri)
+                    torrentManager.downloader.await().fetchTorrent(location.uri),
+                    episode,
                 )
             }
 
             else -> throw UnsupportedMediaException(media)
         }
     }
+
+    companion object {
+        private val DEFAULT_VIDEO_EXTENSIONS =
+            setOf("mp4", "mkv", "avi", "mpeg", "mov", "flv", "wmv", "webm", "rm", "rmvb")
+
+        fun selectVideoFileEntry(
+            entries: List<TorrentFileEntry>,
+            episodeTitles: List<String>,
+            episodeSort: EpisodeSort,
+            videoExtensions: Set<String> = DEFAULT_VIDEO_EXTENSIONS,
+        ): TorrentFileEntry? {
+            // Filter by file extension
+            val videos = entries.filter {
+                videoExtensions.any { fileType -> it.filePath.endsWith(fileType, ignoreCase = true) }
+            }
+
+            // Find by name match
+            for (episodeTitle in episodeTitles) {
+                val entry = videos.singleOrNull {
+                    it.filePath.contains(episodeTitle, ignoreCase = true)
+                }
+                if (entry != null) return entry
+            }
+
+            // 解析标题匹配集数
+            val parsedTitles = videos.associateWith {
+                RawTitleParser.getDefault().parse(it.filePath.substringBeforeLast("."), null).episodeRange
+            }
+            if (parsedTitles.isNotEmpty()) {
+                parsedTitles.entries.firstOrNull {
+                    it.value?.contains(episodeSort) == true
+                }?.key?.let { return it }
+            }
+
+            // 解析失败, 尽可能匹配一个
+            episodeSort.toString().let { number ->
+                videos.firstOrNull { it.filePath.contains(number, ignoreCase = true) }
+                    ?.let { return it }
+            }
+
+            return videos.firstOrNull()
+        }
+    }
 }
 
 private class TorrentVideoSource(
     private val encodedTorrentData: EncodedTorrentData,
+    private val episodeMetadata: EpisodeMetadata,
 ) : VideoSource<TorrentVideoData>, KoinComponent {
     private val manager: TorrentManager by inject()
 
@@ -45,10 +99,33 @@ private class TorrentVideoSource(
     }
 
     override suspend fun open(): TorrentVideoData {
-        return TorrentVideoData(withContext(Dispatchers.IO) {
-            manager.downloader.await().startDownload(encodedTorrentData)
-        })
+        return TorrentVideoData(
+            withContext(Dispatchers.IO) {
+                val files = manager.downloader.await().startDownload(encodedTorrentData)
+                    .getFiles()
+
+                logger.info {
+                    "TorrentVideoSource opening a VideoData, metadata: $episodeMetadata, total ${files.size} files."
+                }
+
+                TorrentVideoSourceResolver.selectVideoFileEntry(
+                    files,
+                    listOf(episodeMetadata.title),
+                    episodeMetadata.sort,
+                )?.also {
+                    logger.info {
+                        "TorrentVideoSource selected file: ${it.filePath}"
+                    }
+                }?.createHandle()?.also {
+                    it.resume(FilePriority.HIGH)
+                } ?: throw VideoSourceOpenException(OpenFailures.NO_MATCHING_FILE)
+            },
+        )
     }
 
-    override fun toString(): String = "TorrentVideoSource(uri=$uri)"
+    override fun toString(): String = "TorrentVideoSource(uri=$uri, episodeMetadata=${episodeMetadata})"
+
+    companion object {
+        val logger = logger<TorrentVideoSource>()
+    }
 }

--- a/app/shared/data/common/data/media/resolver/VideoSourceResolver.kt
+++ b/app/shared/data/common/data/media/resolver/VideoSourceResolver.kt
@@ -21,7 +21,7 @@ interface VideoSourceResolver {
      * @throws UnsupportedOperationException if the media cannot be resolved.
      * Use [supports] to check if the media can be resolved.
      */
-    suspend fun resolve(media: Media, episode: EpisodeSort): VideoSource<*>
+    suspend fun resolve(media: Media, episode: EpisodeMetadata): VideoSource<*>
 
     companion object {
         fun from(vararg resolvers: VideoSourceResolver): VideoSourceResolver {
@@ -34,6 +34,11 @@ interface VideoSourceResolver {
     }
 }
 
+data class EpisodeMetadata(
+    val title: String,
+    val sort: EpisodeSort,
+)
+
 class UnsupportedMediaException(
     val media: Media,
 ) : UnsupportedOperationException("Media is not supported: $media")
@@ -45,7 +50,7 @@ private class ChainedVideoSourceResolver(
         return resolvers.any { it.supports(media) }
     }
 
-    override suspend fun resolve(media: Media, episode: EpisodeSort): VideoSource<*> {
+    override suspend fun resolve(media: Media, episode: EpisodeMetadata): VideoSource<*> {
         return resolvers.firstOrNull { it.supports(media) }?.resolve(media, episode)
             ?: throw UnsupportedMediaException(media)
     }

--- a/app/shared/foundation/common/ui/foundation/HasBackgroundScope.kt
+++ b/app/shared/foundation/common/ui/foundation/HasBackgroundScope.kt
@@ -31,6 +31,7 @@ import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.supervisorScope
+import kotlinx.coroutines.withContext
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.time.Duration.Companion.seconds
@@ -255,9 +256,13 @@ interface HasBackgroundScope {
         coroutineContext: CoroutineContext = EmptyCoroutineContext,
     ): State<T> {
         val state = mutableStateOf(initialValue)
-        launchInMain(coroutineContext) {
+        launchInBackground(coroutineContext) {
             flowOn(Dispatchers.Default) // compute in background
-                .collect { state.value = it } // update state in main
+                .collect {
+                    withContext(Dispatchers.Main) { // ensure a dispatch happens
+                        state.value = it
+                    }
+                } // update state in main
         }
         return state
     }
@@ -270,9 +275,13 @@ interface HasBackgroundScope {
         coroutineContext: CoroutineContext = EmptyCoroutineContext,
     ): FloatState {
         val state = mutableFloatStateOf(initialValue)
-        launchInMain(coroutineContext) {
+        launchInBackground(coroutineContext) {
             flowOn(Dispatchers.Default) // compute in background
-                .collect { state.value = it } // update state in main
+                .collect {
+                    withContext(Dispatchers.Main) { // ensure a dispatch happens
+                        state.value = it
+                    }
+                } // update state in main
         }
         return state
     }
@@ -285,9 +294,13 @@ interface HasBackgroundScope {
         coroutineContext: CoroutineContext = EmptyCoroutineContext,
     ): MutableIntState {
         val state = mutableIntStateOf(initialValue)
-        launchInMain(coroutineContext) {
+        launchInBackground(coroutineContext) {
             flowOn(Dispatchers.Default) // compute in background
-                .collect { state.value = it } // update state in main
+                .collect {
+                    withContext(Dispatchers.Main) { // ensure a dispatch happens
+                        state.value = it
+                    }
+                } // update state in main
         }
         return state
     }
@@ -300,9 +313,13 @@ interface HasBackgroundScope {
         coroutineContext: CoroutineContext = EmptyCoroutineContext,
     ): State<T> {
         val state = mutableStateOf(initialValue)
-        launchInMain(coroutineContext) {
+        launchInBackground(coroutineContext) {
             // no need for flowOn as it's SharedFlow
-            collect { state.value = it }
+            collect {
+                withContext(Dispatchers.Main) {
+                    state.value = it
+                }
+            }
         }
         return state
     }

--- a/app/shared/pages/cache-manage/android/CacheManagePage.android.kt
+++ b/app/shared/pages/cache-manage/android/CacheManagePage.android.kt
@@ -127,17 +127,17 @@ private class TestMediaCacheStorage() : MediaCacheStorage {
         }
     }
     override val stats: MediaStats = emptyMediaStats()
-    override suspend fun findCache(media: Media, resume: Boolean): MediaCache? {
-        return listFlow.first().firstOrNull { it.origin.mediaId == media.mediaId }
-    }
+//    override suspend fun findCache(media: Media, metadata: MediaCacheMetadata, resume: Boolean): MediaCache? {
+//        return listFlow.first().firstOrNull { it.origin.mediaId == media.mediaId }
+//    }
 
     override suspend fun cache(media: Media, metadata: MediaCacheMetadata, resume: Boolean): MediaCache {
         throw UnsupportedOperationException()
     }
 
-    override suspend fun delete(media: Media): Boolean {
-        if (listFlow.first().any { it.origin.mediaId == media.mediaId }) {
-            listFlow.value = listFlow.first().filter { it.origin.mediaId != media.mediaId }
+    override suspend fun delete(cache: MediaCache): Boolean {
+        if (listFlow.first().any { it == cache }) {
+            listFlow.value = listFlow.first().filter { it != cache }
             return true
         }
         return false

--- a/app/shared/pages/episode-play/common/EpisodePage.kt
+++ b/app/shared/pages/episode-play/common/EpisodePage.kt
@@ -243,7 +243,6 @@ private fun EpisodeVideo(
     val context by rememberUpdatedState(LocalContext.current)
 
     // 视频
-    val selected by vm.mediaSelected.collectAsStateWithLifecycle(false)
     val danmakuConfig by vm.danmaku.config.collectAsStateWithLifecycle(DanmakuConfig.Default)
 
     val danmakuEnabled by vm.danmaku.enabled.collectAsStateWithLifecycle(false)
@@ -263,7 +262,7 @@ private fun EpisodeVideo(
         },
         videoSourceState = { videoSourceState },
         danmakuHostState = vm.danmaku.danmakuHostState,
-        videoSourceSelected = { selected },
+        videoSourceSelected = { vm.mediaSelected },
         danmakuConfig = { danmakuConfig },
         onClickFullScreen = {
             if (vm.isFullscreen) {

--- a/app/shared/pages/episode-play/common/EpisodePage.kt
+++ b/app/shared/pages/episode-play/common/EpisodePage.kt
@@ -247,10 +247,10 @@ private fun EpisodeVideo(
     val danmakuConfig by vm.danmaku.config.collectAsStateWithLifecycle(DanmakuConfig.Default)
 
     val danmakuEnabled by vm.danmaku.enabled.collectAsStateWithLifecycle(false)
+    val videoSourceState by vm.videoSourceState.collectAsStateWithLifecycle(VideoSourceState.Initial)
     EpisodeVideo(
         vm.playerState,
         expanded = expanded,
-        maintainAspectRatio = maintainAspectRatio,
         title = {
             val episode = vm.episodePresentation
             val subject = vm.subjectPresentation
@@ -261,6 +261,7 @@ private fun EpisodeVideo(
                 modifier.placeholder(episode.isPlaceholder || subject.isPlaceholder)
             )
         },
+        videoSourceState = { videoSourceState },
         danmakuHostState = vm.danmaku.danmakuHostState,
         videoSourceSelected = { selected },
         danmakuConfig = { danmakuConfig },
@@ -276,9 +277,10 @@ private fun EpisodeVideo(
         danmakuEnabled = { danmakuEnabled },
         setDanmakuEnabled = { vm.launchInBackground { danmaku.setEnabled(it) } },
         onSendDanmaku = {},
-        initialControllerVisible = initialControllerVisible,
         modifier = Modifier.fillMaxWidth().background(Color.Black)
-            .then(if (expanded) Modifier.fillMaxSize() else Modifier.statusBarsPadding())
+            .then(if (expanded) Modifier.fillMaxSize() else Modifier.statusBarsPadding()),
+        maintainAspectRatio = maintainAspectRatio,
+        initialControllerVisible = initialControllerVisible
     )
 }
 

--- a/app/shared/pages/episode-play/common/EpisodeVideo.kt
+++ b/app/shared/pages/episode-play/common/EpisodeVideo.kt
@@ -63,6 +63,7 @@ internal fun EpisodeVideo(
     title: @Composable () -> Unit,
     danmakuHostState: DanmakuHostState,
     videoSourceSelected: () -> Boolean,
+    videoSourceState: () -> VideoSourceState,
     danmakuConfig: () -> DanmakuConfig,
     onClickFullScreen: () -> Unit,
     danmakuEnabled: () -> Boolean,
@@ -159,7 +160,7 @@ internal fun EpisodeVideo(
         },
         floatingMessage = {
             Column {
-                EpisodeVideoLoadingIndicator(playerState, videoSourceSelected())
+                EpisodeVideoLoadingIndicator(playerState, videoSourceSelected(), videoSourceState)
             }
         },
         rhsBar = {

--- a/app/shared/pages/episode-play/common/EpisodeViewModel.kt
+++ b/app/shared/pages/episode-play/common/EpisodeViewModel.kt
@@ -44,6 +44,7 @@ import me.him188.ani.app.videoplayer.ui.state.PlayerStateFactory
 import me.him188.ani.danmaku.api.Danmaku
 import me.him188.ani.danmaku.api.DanmakuMatchers
 import me.him188.ani.danmaku.api.DanmakuProvider
+import me.him188.ani.danmaku.api.DanmakuSearchRequest
 import me.him188.ani.datasources.api.EpisodeSort
 import me.him188.ani.datasources.api.Media
 import me.him188.ani.datasources.bangumi.processing.nameCNOrName
@@ -290,14 +291,27 @@ private class EpisodeViewModelImpl(
             ?: media.originalTitle
         logger.info { "Search for danmaku with filename='$filename', fileHash=${video.fileHash}, length=${video}" }
 
+        val subject: SubjectPresentation
+        val episode: EpisodePresentation
+        withContext(Dispatchers.Main.immediate) {
+            subject = subjectPresentation
+            episode = episodePresentation
+        }
         danmakuProvider.startSession(
-            filename,
-            video.fileHash ?: "aa".repeat(16),
-            video.fileLengthBytes,
-            video.durationMillis.milliseconds,
-            DanmakuMatchers.mostRelevant(
-                subjectPresentation.title,
-                "第${episodePresentation.sort.removePrefix("0")}话 " + episodePresentation.title
+            request = DanmakuSearchRequest(
+                subjectId = subjectId,
+                subjectName = subject.title,
+                episodeId = episodeId,
+                episodeSort = EpisodeSort(episode.sort),
+                episodeName = episode.title,
+                filename = filename,
+                fileHash = video.fileHash ?: "aa".repeat(16),
+                fileSize = video.fileLengthBytes,
+                videoDuration = video.durationMillis.milliseconds,
+            ),
+            matcher = DanmakuMatchers.mostRelevant(
+                subject.title,
+                "第${episode.sort.removePrefix("0")}话 " + episode.title
             ),
         )
     }.filterNotNull()

--- a/app/shared/pages/episode-play/common/EpisodeViewModel.kt
+++ b/app/shared/pages/episode-play/common/EpisodeViewModel.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
@@ -285,7 +286,7 @@ private class EpisodeViewModelImpl(
 
     private val danmakuFlow: Flow<Danmaku> = combine(
         selectedMedia.filterNotNull(),
-        playerState.videoProperties.filterNotNull()
+        playerState.videoProperties.distinctUntilChangedBy { it?.filename }.filterNotNull()
     ) { media, video ->
         val filename = video.filename.takeIf { it.isNotBlank() }
             ?: video.title

--- a/app/shared/pages/episode-play/common/EpisodeViewModel.kt
+++ b/app/shared/pages/episode-play/common/EpisodeViewModel.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterNotNull
@@ -319,6 +320,7 @@ private class EpisodeViewModelImpl(
         .flatMapLatest { session ->
             session.at(playerState.currentPositionMillis.map { it.milliseconds })
         }
+        .shareInBackground(started = SharingStarted.Lazily)
 
     init {
         launchInMain { // state changes must be in main thread

--- a/app/shared/pages/episode-play/common/details/EpisodeDetails.kt
+++ b/app/shared/pages/episode-play/common/details/EpisodeDetails.kt
@@ -22,6 +22,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -39,6 +40,7 @@ import me.him188.ani.datasources.api.Media
 import me.him188.ani.datasources.api.topic.FileSize.Companion.bytes
 import me.him188.ani.datasources.api.topic.Resolution
 import me.him188.ani.datasources.api.topic.SubtitleLanguage
+import moe.tlaster.precompose.flow.collectAsStateWithLifecycle
 
 private val PAGE_HORIZONTAL_PADDING = 16.dp
 
@@ -135,12 +137,16 @@ private fun NowPlayingLabel(viewModel: EpisodeViewModel, modifier: Modifier = Mo
                         )
                     }
 
-                    SelectionContainer {
-                        Text(
-                            remember(playing) { playing.originalTitle },
-                            Modifier.padding(top = 8.dp),
-                            color = LocalContentColor.current.slightlyWeaken(),
-                        )
+
+                    val data by viewModel.playerState.videoData.collectAsStateWithLifecycle(null)
+                    if (data != null) {
+                        SelectionContainer {
+                            Text(
+                                remember(data) { data?.filename ?: "" },
+                                Modifier.padding(top = 8.dp),
+                                color = LocalContentColor.current.slightlyWeaken(),
+                            )
+                        }
                     }
                 }
             } else {

--- a/app/shared/pages/episode-play/common/mediaFetch/EpisodeMediaFetchSession.kt
+++ b/app/shared/pages/episode-play/common/mediaFetch/EpisodeMediaFetchSession.kt
@@ -253,7 +253,7 @@ internal class DefaultEpisodeMediaFetchSession(
                         if (!defaultPreferencesFetched) return@combine // wait for config load
 
                         // on completion
-                        withContext(Dispatchers.Main.immediate) {
+                        withContext(Dispatchers.Main) {
                             if (selected == null) { // only if user has not selected
                                 makeDefaultSelection()
                             }

--- a/app/shared/pages/episode-play/common/video/loading/EpisodeVideoLoadingIndicator.kt
+++ b/app/shared/pages/episode-play/common/video/loading/EpisodeVideoLoadingIndicator.kt
@@ -3,6 +3,7 @@ package me.him188.ani.app.ui.subject.episode.video.loading
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.Stable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -15,6 +16,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
+import me.him188.ani.app.ui.subject.episode.VideoSourceState
 import me.him188.ani.app.videoplayer.ui.VideoLoadingIndicator
 import me.him188.ani.app.videoplayer.ui.state.PlayerState
 import me.him188.ani.datasources.api.topic.FileSize
@@ -25,6 +27,7 @@ import kotlin.time.Duration.Companion.seconds
 fun EpisodeVideoLoadingIndicator(
     playerState: PlayerState,
     mediaSelected: Boolean,
+    videoSourceState: () -> VideoSourceState,
     modifier: Modifier = Modifier,
 ) {
     val isBuffering by playerState.isBuffering.collectAsStateWithLifecycle(true)
@@ -37,30 +40,39 @@ fun EpisodeVideoLoadingIndicator(
         playerState.videoData.filterNotNull().flatMapLatest { it.downloadSpeed }
     }.collectAsStateWithLifecycle(FileSize.Unspecified)
 
-    if (isBuffering) {
+    if (isBuffering || !videoDataReady) {
         EpisodeVideoLoadingIndicator(
-            EpisodeVideoLoadingState.deduceFrom(mediaSelected, videoDataReady),
+            EpisodeVideoLoadingState.deduceFrom(mediaSelected, videoDataReady, videoSourceState()),
             speedProvider = { speed },
             modifier,
         )
     }
 }
 
-enum class EpisodeVideoLoadingState {
-    SELECTING_MEDIA,
-    PREPARING,
-    BUFFERING, ;
+sealed class EpisodeVideoLoadingState {
 
     companion object {
+        @Stable
         fun deduceFrom(
             mediaSelected: Boolean,
             videoDataReady: Boolean,
-        ): EpisodeVideoLoadingState = when {
-            !mediaSelected -> SELECTING_MEDIA
-            !videoDataReady -> PREPARING
-            else -> BUFFERING
+            videoSourceState: VideoSourceState = VideoSourceState.Initial,
+        ): EpisodeVideoLoadingState {
+            return when {
+                !mediaSelected -> SelectingMedia
+                videoSourceState == VideoSourceState.Resolving -> Resolving
+                videoSourceState is VideoSourceState.Failed -> Failed(videoSourceState)
+                !videoDataReady -> Preparing
+                else -> Buffering
+            }
         }
     }
+
+    data object SelectingMedia : EpisodeVideoLoadingState()
+    data object Preparing : EpisodeVideoLoadingState()
+    data object Buffering : EpisodeVideoLoadingState()
+    data object Resolving : EpisodeVideoLoadingState()
+    data class Failed(val cause: VideoSourceState.Failed) : EpisodeVideoLoadingState()
 }
 
 @Composable
@@ -70,18 +82,18 @@ fun EpisodeVideoLoadingIndicator(
     modifier: Modifier = Modifier,
 ) {
     VideoLoadingIndicator(
-        showProgress = state != EpisodeVideoLoadingState.SELECTING_MEDIA,
+        showProgress = state != EpisodeVideoLoadingState.SelectingMedia,
         text = {
             when (state) {
-                EpisodeVideoLoadingState.SELECTING_MEDIA -> {
+                EpisodeVideoLoadingState.SelectingMedia -> {
                     Text("请选择数据源")
                 }
 
-                EpisodeVideoLoadingState.PREPARING -> {
+                EpisodeVideoLoadingState.Preparing -> {
                     Text("正在准备资源")
                 }
 
-                EpisodeVideoLoadingState.BUFFERING -> {
+                EpisodeVideoLoadingState.Buffering -> {
                     var tooLong by rememberSaveable {
                         mutableStateOf(false)
                     }
@@ -104,7 +116,7 @@ fun EpisodeVideoLoadingIndicator(
 
                                 if (tooLong) {
                                     appendLine()
-                                    append("检测到连接异常, 如有使用代理请尝试关闭后重启应用")
+                                    append("检测到连接缓慢, 如有使用代理请尝试关闭后重启应用")
                                 }
                             }
                         }
@@ -112,8 +124,22 @@ fun EpisodeVideoLoadingIndicator(
 
                     Text(text, textAlign = TextAlign.Center)
                 }
+
+                is EpisodeVideoLoadingState.Failed -> {
+                    Text("加载失败: ${renderCause(state.cause)}")
+                }
+
+                EpisodeVideoLoadingState.Resolving -> {
+                    Text("正在解析资源")
+                }
             }
         },
         modifier,
     )
+}
+
+fun renderCause(cause: VideoSourceState.Failed): String = when (cause) {
+    is VideoSourceState.ResolutionTimedOut -> "解析超时"
+    is VideoSourceState.UnknownError -> "未知错误"
+    is VideoSourceState.UnsupportedMedia -> "不支持该文件类型"
 }

--- a/app/shared/pages/episode-play/common/video/loading/EpisodeVideoLoadingIndicator.kt
+++ b/app/shared/pages/episode-play/common/video/loading/EpisodeVideoLoadingIndicator.kt
@@ -2,11 +2,16 @@ package me.him188.ani.app.ui.subject.episode.video.loading
 
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
@@ -14,6 +19,7 @@ import me.him188.ani.app.videoplayer.ui.VideoLoadingIndicator
 import me.him188.ani.app.videoplayer.ui.state.PlayerState
 import me.him188.ani.datasources.api.topic.FileSize
 import moe.tlaster.precompose.flow.collectAsStateWithLifecycle
+import kotlin.time.Duration.Companion.seconds
 
 @Composable // see preview
 fun EpisodeVideoLoadingIndicator(
@@ -76,7 +82,16 @@ fun EpisodeVideoLoadingIndicator(
                 }
 
                 EpisodeVideoLoadingState.BUFFERING -> {
+                    var tooLong by rememberSaveable {
+                        mutableStateOf(false)
+                    }
                     val speed by remember { derivedStateOf(speedProvider) }
+                    if (speed == FileSize.Zero) {
+                        LaunchedEffect(true) {
+                            delay(5.seconds)
+                            tooLong = true
+                        }
+                    }
                     val text by remember(speed) {
                         derivedStateOf {
                             buildString {
@@ -85,6 +100,11 @@ fun EpisodeVideoLoadingIndicator(
                                     appendLine()
                                     append(speed.toString())
                                     append("/s")
+                                }
+
+                                if (tooLong) {
+                                    appendLine()
+                                    append("检测到连接异常, 如有使用代理请尝试关闭后重启应用")
                                 }
                             }
                         }

--- a/app/shared/video-player/android/PlayerState.android.kt
+++ b/app/shared/video-player/android/PlayerState.android.kt
@@ -35,6 +35,7 @@ import me.him188.ani.app.videoplayer.ui.state.AbstractPlayerState
 import me.him188.ani.app.videoplayer.ui.state.PlaybackState
 import me.him188.ani.app.videoplayer.ui.state.PlayerState
 import me.him188.ani.app.videoplayer.ui.state.PlayerStateFactory
+import me.him188.ani.utils.logging.error
 import me.him188.ani.utils.logging.info
 import me.him188.ani.utils.logging.logger
 import kotlin.coroutines.CoroutineContext
@@ -111,8 +112,9 @@ internal class ExoPlayerState @UiThread constructor(
                 player.prepare()
                 player.play()
             }
-            logger.info { "Player initialized" }
+            logger.info { "ExoPlayer is now initialized with media and will play when ready" }
         } catch (e: Throwable) {
+            logger.error(e) { "ExoPlayer failed to initialize" }
             opened.releaseResource()
             throw e
         }
@@ -148,6 +150,7 @@ internal class ExoPlayerState @UiThread constructor(
                 private fun updateVideoProperties(): Boolean {
                     val video = videoFormat ?: return false
                     val audio = audioFormat ?: return false
+                    val data = openResource.value?.data ?: return false
                     videoProperties.value = VideoProperties(
                         title = mediaMetadata.title?.toString(),
                         heightPx = video.height,
@@ -156,8 +159,9 @@ internal class ExoPlayerState @UiThread constructor(
                         audioBitrate = audio.bitrate,
                         frameRate = video.frameRate,
                         durationMillis = duration,
-                        fileLengthBytes = openResource.value?.data?.fileLength ?: 0L,
-                        fileHash = openResource.value?.data?.hash
+                        fileLengthBytes = data.fileLength,
+                        fileHash = data.hash,
+                        filename = data.filename,
                     )
                     return true
                 }

--- a/app/shared/video-player/android/media/VideoDataDataSource.kt
+++ b/app/shared/video-player/android/media/VideoDataDataSource.kt
@@ -59,14 +59,12 @@ class VideoDataDataSource(
             this.uri = uri
             transferInitializing(dataSpec)
 
-            logger.info { "Acquiring torrent DeferredFile" }
+            logger.info { "Acquiring SeekableInput (via videoData.createInput)" }
             file = runBlocking { videoData.createInput() }
             opened = true
         }
 
-        logger.info { "Waiting for totalBytes" }
-
-        val torrentLength = runBlocking { videoData.fileLength }
+        val torrentLength = videoData.fileLength
 
         logger.info { "torrentLength = $torrentLength" }
 

--- a/app/shared/video-player/common/data/VideoData.kt
+++ b/app/shared/video-player/common/data/VideoData.kt
@@ -10,6 +10,8 @@ import me.him188.ani.utils.io.SeekableInput
  */
 @Stable
 interface VideoData : AutoCloseable {
+    val filename: String
+    
     /**
      * Returns the length of the video file in bytes.
      */
@@ -44,4 +46,6 @@ interface VideoData : AutoCloseable {
      * Otherwise, it is undefined behavior.
      */
     suspend fun createInput(): SeekableInput
+
+    override fun close()
 }

--- a/app/shared/video-player/common/data/VideoProperties.kt
+++ b/app/shared/video-player/common/data/VideoProperties.kt
@@ -13,7 +13,8 @@ data class VideoProperties internal constructor(
     val frameRate: Float,
     val durationMillis: Long,
     val fileLengthBytes: Long,
-    val fileHash: String? = null, // 16 bytes
+    val fileHash: String?, // 16 bytes
+    val filename: String,
 ) {
     companion object {
         @Stable
@@ -25,7 +26,9 @@ data class VideoProperties internal constructor(
             audioBitrate = 0,
             frameRate = 0f,
             durationMillis = 0,
-            fileLengthBytes = 0
+            fileLengthBytes = 0,
+            fileHash = null,
+            filename = "",
         )
     }
 }

--- a/app/shared/video-player/common/data/VideoSource.kt
+++ b/app/shared/video-player/common/data/VideoSource.kt
@@ -30,6 +30,21 @@ interface VideoSource<S : VideoData> {
      * Note that [S] should be closed by the caller.
      *
      * Repeat calls to this function may return different instances so it may be desirable to store the result.
+     *
+     * @throws VideoSourceOpenException 当打开失败时抛出, 包含原因
      */
+    @Throws(VideoSourceOpenException::class)
     suspend fun open(): S
 }
+
+enum class OpenFailures {
+    /**
+     * 未找到符合剧集描述的文件
+     */
+    NO_MATCHING_FILE,
+}
+
+class VideoSourceOpenException(
+    val reason: OpenFailures,
+    override val cause: Throwable? = null,
+) : Exception("Failed to open video source: $reason", cause)

--- a/app/shared/video-player/common/torrent/FileVideoSource.kt
+++ b/app/shared/video-player/common/torrent/FileVideoSource.kt
@@ -16,6 +16,8 @@ import java.io.RandomAccessFile
 class FileVideoData(
     private val file: File,
 ) : VideoData {
+    override val filename: String
+        get() = file.name
     override val fileLength: Long by lazy { file.length() }
     override val hash: String by lazy { md5Hash(file) }
     override val downloadSpeed: StateFlow<FileSize> = MutableStateFlow(FileSize.Unspecified)

--- a/app/shared/video-player/common/torrent/TorrentVideoData.kt
+++ b/app/shared/video-player/common/torrent/TorrentVideoData.kt
@@ -1,25 +1,31 @@
 package me.him188.ani.app.videoplayer.torrent
 
 import kotlinx.coroutines.flow.map
-import me.him188.ani.app.torrent.TorrentDownloadSession
+import me.him188.ani.app.torrent.TorrentFileHandle
 import me.him188.ani.app.videoplayer.data.VideoData
 import me.him188.ani.datasources.api.topic.FileSize
 import me.him188.ani.datasources.api.topic.FileSize.Companion.bytes
 import me.him188.ani.utils.io.SeekableInput
 
 class TorrentVideoData(
-    val session: TorrentDownloadSession,
+    private val handle: TorrentFileHandle,
 ) : VideoData {
-    override val fileLength: Long get() = session.fileLength
+    private inline val entry get() = handle.entry
+    override val filename: String get() = entry.filePath
+    override val fileLength: Long get() = entry.length
 
-    override val hash: String? get() = session.fileHash
+    override val hash: String? get() = entry.getFileHashOrNull()
 
-    override val downloadSpeed get() = session.downloadRate.map { it?.bytes ?: FileSize.Unspecified }
-    override val uploadRate get() = session.uploadRate.map { it?.bytes ?: FileSize.Unspecified }
+    override val downloadSpeed get() = entry.stats.downloadRate.map { it?.bytes ?: FileSize.Unspecified }
+    override val uploadRate get() = entry.stats.uploadRate.map { it?.bytes ?: FileSize.Unspecified }
 
-    override suspend fun createInput(): SeekableInput = session.createInput()
+    override suspend fun createInput(): SeekableInput = entry.createInput()
 
     override fun close() {
-        session.close()
+        handle.close()
+    }
+
+    override fun toString(): String {
+        return "TorrentVideoData(entry=$entry)"
     }
 }

--- a/app/shared/video-player/common/ui/state/PlayerState.kt
+++ b/app/shared/video-player/common/ui/state/PlayerState.kt
@@ -188,7 +188,9 @@ class DummyPlayerState : AbstractPlayerState() {
             audioBitrate = 100,
             frameRate = 30f,
             durationMillis = 100_000,
-            fileLengthBytes = 100_000_000
+            fileLengthBytes = 100_000_000,
+            fileHash = null,
+            filename = "test.mp4"
         )
     )
     override val currentPositionMillis = MutableStateFlow(10_000L)

--- a/danmaku/api/src/DanmakuProvider.kt
+++ b/danmaku/api/src/DanmakuProvider.kt
@@ -1,6 +1,7 @@
 package me.him188.ani.danmaku.api
 
 import kotlinx.serialization.Serializable
+import me.him188.ani.datasources.api.EpisodeSort
 import kotlin.time.Duration
 
 /**
@@ -15,13 +16,23 @@ interface DanmakuProvider {
      * The returned [DanmakuSession] should be closed when it is no longer needed.
      */
     suspend fun startSession(
-        filename: String,
-        fileHash: String?,
-        fileSize: Long,
-        videoDuration: Duration,
+        request: DanmakuSearchRequest,
         matcher: DanmakuMatcher,
     ): DanmakuSession?
 }
+
+class DanmakuSearchRequest(
+    val subjectId: Int,
+    val subjectName: String,
+    val episodeId: Int,
+    val episodeSort: EpisodeSort,
+    val episodeName: String,
+
+    val filename: String,
+    val fileHash: String?,
+    val fileSize: Long,
+    val videoDuration: Duration,
+)
 
 fun interface DanmakuMatcher {
     fun match(list: List<DanmakuEpisode>): DanmakuEpisode?

--- a/danmaku/dandanplay/src/DandanplayClient.kt
+++ b/danmaku/dandanplay/src/DandanplayClient.kt
@@ -41,7 +41,8 @@ class DandanplayClient(
             delayMillis { 2000 }
         }
         install(HttpTimeout) {
-            requestTimeoutMillis = 10_000 // 弹弹服务器请求比较慢
+            requestTimeoutMillis = 20_000 // 弹弹服务器请求比较慢
+            connectTimeoutMillis = 10_000 // 弹弹服务器请求比较慢
         }
         install(ContentNegotiation) {
             json(Json {

--- a/danmaku/dandanplay/src/DandanplayDanmakuProvider.kt
+++ b/danmaku/dandanplay/src/DandanplayDanmakuProvider.kt
@@ -3,27 +3,47 @@ package me.him188.ani.danmaku.dandanplay
 import me.him188.ani.danmaku.api.DanmakuEpisode
 import me.him188.ani.danmaku.api.DanmakuMatcher
 import me.him188.ani.danmaku.api.DanmakuProvider
+import me.him188.ani.danmaku.api.DanmakuSearchRequest
 import me.him188.ani.danmaku.api.DanmakuSession
 import me.him188.ani.danmaku.api.TimeBasedDanmakuSession
+import me.him188.ani.danmaku.dandanplay.data.toDanmakuOrNull
 import me.him188.ani.utils.logging.info
 import me.him188.ani.utils.logging.logger
-import kotlin.time.Duration
 
 class DandanplayDanmakuProvider(
     private val dandanplayClient: DandanplayClient,
 ) : DanmakuProvider {
     override suspend fun startSession(
-        filename: String,
-        fileHash: String?,
-        fileSize: Long,
-        videoDuration: Duration,
+        request: DanmakuSearchRequest,
         matcher: DanmakuMatcher,
     ): DanmakuSession? {
+        val searchEpisodeResponse = dandanplayClient.searchEpisode(
+            subjectName = request.subjectName,
+            episodeName = "第${request.episodeSort.toString().removePrefix("0")}话",
+            // 弹弹数据库有时候会只有 "第x话" 没有具体标题, 所以不带标题搜索就够了
+        )
+        logger.info { "Ep search result: ${searchEpisodeResponse}}" }
+        val episodes = searchEpisodeResponse.animes.flatMap { it ->
+            it.episodes.map { ep ->
+                DanmakuEpisode(
+                    id = ep.episodeId.toString(),
+                    subjectName = it.animeTitle ?: "",
+                    episodeName = ep.episodeTitle ?: "",
+                )
+            }
+        }
+        if (episodes.isNotEmpty()) {
+            matcher.match(episodes)?.let {
+                logger.info { "Matched episode by ep search: ${it.subjectName} - ${it.episodeName}" }
+                return createSession(it.id.toLong(), 0)
+            }
+        }
+
         val resp = dandanplayClient.matchVideo(
-            filename = filename,
-            fileHash = fileHash,
-            fileSize = fileSize,
-            videoDuration = videoDuration
+            filename = request.filename,
+            fileHash = request.fileHash,
+            fileSize = request.fileSize,
+            videoDuration = request.videoDuration
         )
         val match = if (resp.isMatched) {
             resp.matches.firstOrNull() ?: return null
@@ -37,12 +57,19 @@ class DandanplayDanmakuProvider(
                 resp.matches.first { it.episodeId.toString() == match.id }
             } ?: return null
         }
-        logger.info { "Best match: ${match.animeTitle} - ${match.episodeTitle}" }
+        logger.info { "Best match by file match: ${match.animeTitle} - ${match.episodeTitle}" }
         val episodeId = match.episodeId
+        return createSession(episodeId, (match.shift * 1000L).toLong())
+    }
+
+    private suspend fun createSession(
+        episodeId: Long,
+        shiftMillis: Long
+    ): DanmakuSession {
         val list = dandanplayClient.getDanmakuList(episodeId = episodeId)
         return TimeBasedDanmakuSession.create(
             list.asSequence().mapNotNull { it.toDanmakuOrNull() },
-            shiftMillis = (match.shift * 1000L).toLong(),
+            shiftMillis = shiftMillis,
         )
     }
 

--- a/danmaku/dandanplay/src/data/MatchEpisode.kt
+++ b/danmaku/dandanplay/src/data/MatchEpisode.kt
@@ -1,0 +1,48 @@
+package me.him188.ani.danmaku.dandanplay.data
+
+import kotlinx.serialization.Serializable
+
+/*
+SearchEpisodesResponse {
+hasMore (boolean): 是否有更多未显示的搜索结果。当返回的搜索结果过多时此值为true ,
+animes (Array[SearchEpisodesAnime], optional): 搜索结果（作品信息）列表 ,
+errorCode (integer): 错误代码，0表示没有发生错误，非0表示有错误，详细信息会包含在errorMessage属性中 ,
+success (boolean, read only): 接口是否调用成功 ,
+errorMessage (string, optional, read only): 当发生错误时，说明错误具体原因
+}
+SearchEpisodesAnime {
+animeId (integer): 作品编号 ,
+animeTitle (string, optional): 作品标题 ,
+type (string): 作品类型 = ['tvseries', 'tvspecial', 'ova', 'movie', 'musicvideo', 'web', 'other', 'jpmovie', 'jpdrama', 'unknown'],
+typeDescription (string, optional): 类型描述 ,
+episodes (Array[SearchEpisodeDetails], optional): 此作品的剧集列表
+}
+SearchEpisodeDetails {
+episodeId (integer): 剧集ID（弹幕库编号） ,
+episodeTitle (string, optional): 剧集标题
+}
+ */
+
+@Serializable
+data class DandanplaySearchEpisodeResponse(
+    val hasMore: Boolean = false,
+    val animes: List<SearchEpisodesAnime> = listOf(),
+    val errorCode: Int = 0,
+    val success: Boolean = true,
+    val errorMessage: String? = null,
+)
+
+@Serializable
+data class SearchEpisodesAnime(
+    val animeId: Int,
+    val animeTitle: String? = null,
+    val type: String,
+    val typeDescription: String? = null,
+    val episodes: List<SearchEpisodeDetails> = listOf(),
+)
+
+@Serializable
+data class SearchEpisodeDetails(
+    val episodeId: Int,
+    val episodeTitle: String? = null,
+)

--- a/danmaku/dandanplay/src/data/MatchVideo.kt
+++ b/danmaku/dandanplay/src/data/MatchVideo.kt
@@ -1,0 +1,69 @@
+package me.him188.ani.danmaku.dandanplay.data
+
+import kotlinx.serialization.Serializable
+import me.him188.ani.danmaku.api.Danmaku
+import me.him188.ani.danmaku.api.DanmakuLocation
+
+
+@Serializable
+class DandanplayDanmaku(
+    val cid: Long,
+    val p: String,
+    val m: String, // content
+)
+
+fun DandanplayDanmaku.toDanmakuOrNull(): Danmaku? {
+    /*
+    p参数格式为出现时间,模式,颜色,用户ID，各个参数之间使用英文逗号分隔
+
+弹幕出现时间：格式为 0.00，单位为秒，精确到小数点后两位，例如12.34、445.6、789.01
+弹幕模式：1-普通弹幕，4-底部弹幕，5-顶部弹幕
+颜色：32位整数表示的颜色，算法为 Rx256x256+Gx256+B，R/G/B的范围应是0-255
+用户ID：字符串形式表示的用户ID，通常为数字，不会包含特殊字符
+
+     */
+    val (time, mode, color, userId) = p.split(",").let {
+        if (it.size < 4) return null else it
+    }
+
+    return Danmaku(
+        id = cid.toString(),
+        time = time.toDoubleOrNull() ?: return null,
+        senderId = userId,
+        location = when (mode.toIntOrNull()) {
+            1 -> DanmakuLocation.NORMAL
+            4 -> DanmakuLocation.BOTTOM
+            5 -> DanmakuLocation.TOP
+            else -> return null
+        },
+        text = m,
+        color = color.toIntOrNull() ?: return null
+    )
+}
+
+@Serializable
+class DandanplayDanmakuListResponse(
+    val count: Int,
+    val comments: List<DandanplayDanmaku>
+)
+
+// https://api.dandanplay.net/swagger/ui/index#/Match
+@Serializable
+data class DandanplayEpisode(
+    val animeId: Long,
+    val animeTitle: String,
+    val episodeId: Long,
+    val episodeTitle: String,
+    val shift: Double,// 弹幕偏移时间（弹幕应延迟多少秒出现）。此数字为负数时表示弹幕应提前多少秒出现。
+    val type: String,
+    val typeDescription: String
+)
+
+@Serializable
+class DandanplayMatchVideoResponse(
+    val isMatched: Boolean,
+    val matches: List<DandanplayEpisode>,
+    val errorCode: Int,
+    val success: Boolean,
+    val errorMessage: String,
+)

--- a/data-sources/acg.rip/src/AcgRipMediaSource.kt
+++ b/data-sources/acg.rip/src/AcgRipMediaSource.kt
@@ -148,7 +148,7 @@ private fun parseDocument(document: Document): List<Topic> {
     return items.map { element ->
         val title = element.getElementsByTag("title").text()
 
-        val details = RawTitleParser.getParserFor().parse(title, null)
+        val details = RawTitleParser.getDefault().parse(title, null)
 
         Topic(
             topicId = "acgrip-${element.getElementsByTag("guid").text().substringAfterLast("/")}",

--- a/data-sources/api/src/topic/titles/RawTitleParser.kt
+++ b/data-sources/api/src/topic/titles/RawTitleParser.kt
@@ -49,7 +49,7 @@ abstract class RawTitleParser {
 
 
     companion object {
-        fun getParserFor(): RawTitleParser {
+        fun getDefault(): RawTitleParser {
             return PatternBasedRawTitleParser()
 //            when (allianceName) {
 //                "LoliHouse",

--- a/data-sources/core/src/cache/DirectoryMediaCacheStorage.kt
+++ b/data-sources/core/src/cache/DirectoryMediaCacheStorage.kt
@@ -96,6 +96,10 @@ class DirectoryMediaCacheStorage(
                             }
                         }
                         logger.info { "Cache restored: ${save.origin.mediaId}, result=${cache}" }
+                        if (cache != null) {
+                            cache.resume()
+                            logger.info { "Cache resumed: $cache" }
+                        }
                     } catch (e: Exception) {
                         logger.error(e) { "Failed to restore cache for ${save.origin.mediaId}" }
                     }

--- a/data-sources/core/src/cache/MediaCacheStorage.kt
+++ b/data-sources/core/src/cache/MediaCacheStorage.kt
@@ -55,11 +55,6 @@ interface MediaCacheStorage : AutoCloseable {
     val listFlow: Flow<List<MediaCache>>
 
     /**
-     * Returns the cache of the media if it exists, or `null` if it doesn't.
-     */
-    suspend fun findCache(media: Media, resume: Boolean = true): MediaCache?
-
-    /**
      * Finds the existing cache for the media or adds the media to the cache (queue).
      *
      * When this function returns, A new [MediaSource] can then be listed by [listFlow].
@@ -76,13 +71,18 @@ interface MediaCacheStorage : AutoCloseable {
      * Delete the cache if it exists.
      * @return `true` if a cache was deleted, `false` if there wasn't such a cache.
      */
-    suspend fun delete(media: Media): Boolean
+    suspend fun delete(cache: MediaCache): Boolean
 }
 
 /**
  * A media cached in the storage.
  */
 interface MediaCache {
+    val cacheId: String
+        get() = (origin.hashCode() * 31
+                + metadata.subjectId.hashCode() * 31
+                + metadata.episodeId.hashCode()).toString()
+
     /**
      * Original media that is being cached.
      */

--- a/data-sources/core/test/DirectoryMediaCacheStorageTest.kt
+++ b/data-sources/core/test/DirectoryMediaCacheStorageTest.kt
@@ -2,6 +2,7 @@ package me.him188.ani.datasources.core.cache
 
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.test.runTest
 import me.him188.ani.datasources.api.CachedMedia
@@ -121,12 +122,9 @@ class DirectoryMediaCacheStorageTest {
 
         assertSame(
             cache,
-            storage.findCache(
-                media,
-                resume = true,
-            )
+            storage.listFlow.first().single()
         )
-        assertEquals(2, cache.resumeCalled.get())
+        assertEquals(1, cache.resumeCalled.get())
 
         storage.close()
     }
@@ -149,10 +147,7 @@ class DirectoryMediaCacheStorageTest {
 
         assertSame(
             cache,
-            storage.findCache(
-                media,
-                resume = false,
-            )
+            storage.listFlow.first().single()
         )
         assertEquals(0, cache.resumeCalled.get())
 
@@ -176,9 +171,9 @@ class DirectoryMediaCacheStorageTest {
 
         assertEquals(0, cache.resumeCalled.get())
 
-        assertEquals(cache, storage.findCache(media, resume = false))
-        assertEquals(true, storage.delete(media))
-        assertEquals(null, storage.findCache(media, resume = false))
+        assertEquals(cache, storage.listFlow.first().single())
+        assertEquals(true, storage.delete(cache))
+        assertEquals(null, storage.listFlow.first().firstOrNull())
 
         assertEquals(0, cache.resumeCalled.get())
 

--- a/data-sources/dmhy/src/DmhyTopic.kt
+++ b/data-sources/dmhy/src/DmhyTopic.kt
@@ -44,7 +44,7 @@ data class DmhyTopic(
 ) {
     val details: ParsedTopicTitle? by lazy {
         ParsedTopicTitle.Builder().apply {
-            RawTitleParser.getParserFor().parse(rawTitle, alliance?.name, this)
+            RawTitleParser.getDefault().parse(rawTitle, alliance?.name, this)
         }.build()
     }
 }

--- a/data-sources/mikan/src/MikanMediaSource.kt
+++ b/data-sources/mikan/src/MikanMediaSource.kt
@@ -153,7 +153,7 @@ abstract class AbstractMikanMediaSource(
         return items.map { element ->
             val title = element.getElementsByTag("title").text()
 
-            val details = RawTitleParser.getParserFor().parse(title, null)
+            val details = RawTitleParser.getDefault().parse(title, null)
 
             Topic(
                 topicId = element.getElementsByTag("guid").text().substringAfterLast("/"),

--- a/torrent/build.gradle.kts
+++ b/torrent/build.gradle.kts
@@ -46,6 +46,7 @@ kotlin {
         api(libs.kotlinx.coroutines.core)
         implementation(libs.libtorrent4j)
         implementation(projects.utils.slf4jKt)
+        implementation(projects.utils.coroutines)
         api(projects.utils.io)
     }
 

--- a/torrent/commonMain/DownloadStats.kt
+++ b/torrent/commonMain/DownloadStats.kt
@@ -2,14 +2,13 @@ package me.him188.ani.app.torrent
 
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.StateFlow
 
 /**
  * @see TorrentDownloader
  */
 public interface DownloadStats {
     /**
-     * 总大小. 注意这不是在硬盘上的大小. 在硬盘上可能会略有差别.
+     * 总请求大小. 注意这不是在硬盘上的大小. 在硬盘上可能会略有差别.
      */
     public val totalBytes: Flow<Long>
 
@@ -18,13 +17,13 @@ public interface DownloadStats {
     /**
      * Bytes per second. `null` if not available, i.e. just started
      */
-    public val downloadRate: StateFlow<Long?>
+    public val downloadRate: Flow<Long?>
     public val uploadRate: Flow<Long?>
 
     /**
      * Range: `0..1`
      */
-    public val progress: StateFlow<Float>
+    public val progress: Flow<Float>
 
     /**
      * 该文件是否已经全部下载完成.

--- a/torrent/commonMain/DownloadStats.kt
+++ b/torrent/commonMain/DownloadStats.kt
@@ -8,7 +8,11 @@ import kotlinx.coroutines.flow.StateFlow
  * @see TorrentDownloader
  */
 public interface DownloadStats {
+    /**
+     * 总大小. 注意这不是在硬盘上的大小. 在硬盘上可能会略有差别.
+     */
     public val totalBytes: Flow<Long>
+
     public val downloadedBytes: Flow<Long>
 
     /**
@@ -22,6 +26,11 @@ public interface DownloadStats {
      */
     public val progress: StateFlow<Float>
 
+    /**
+     * 该文件是否已经全部下载完成.
+     *
+     * 注意, 对于总统计, 该属性永远为 false.
+     */
     public val isFinished: Flow<Boolean>
 
     public val peerCount: Flow<Int>

--- a/torrent/commonMain/TorrentDownloadSession.kt
+++ b/torrent/commonMain/TorrentDownloadSession.kt
@@ -1,39 +1,26 @@
 package me.him188.ani.app.torrent
 
-import kotlinx.coroutines.flow.Flow
-import me.him188.ani.utils.io.SeekableInput
-import java.nio.file.Path
+import kotlinx.coroutines.flow.StateFlow
+
 
 /**
- * Represents a torrent download session.
- *
- * Needs to be closed.
+ * 表示一整个 BT 资源的下载任务.
  *
  * @See TorrentDownloader
  */
-public interface TorrentDownloadSession : DownloadStats, AutoCloseable {
-//    public val torrentDownloadController: Flow<TorrentDownloadController>
+public interface TorrentDownloadSession : AutoCloseable {
+    public val state: StateFlow<TorrentDownloadState>
 
-    public val state: Flow<TorrentDownloadState>
-
-    public val fileLength: Long
-
-    public val fileHash: String?
-
-    public suspend fun pause()
-
-    public suspend fun resume()
-
-    public suspend fun filePath(): Path
+    public val overallStats: DownloadStats
 
     /**
-     * Opens the downloaded file as a [SeekableInput].
+     * 获取该种子资源中的所有文件.
      */
-    public suspend fun createInput(): SeekableInput
+    public suspend fun getFiles(): List<TorrentFileEntry>
 
     public override fun close()
 
-    public suspend fun closeAndDelete()
+    public suspend fun closeAndDelete() // TODO:  
 }
 
 public sealed class TorrentDownloadState {
@@ -50,13 +37,13 @@ public sealed class TorrentDownloadState {
     public data object FetchingMetadata : TorrentDownloadState()
 
     /**
-     * Pieces are being downloaded.
+     * 当前可以下载文件. 注意, 可能有文件正在下载, 也可能没有.
      */
     public data object Downloading : TorrentDownloadState()
 
     /**
      * All pieces have been downloaded successfully.
      */
-    public data object Finished : TorrentDownloadState()
+    public data object Closed : TorrentDownloadState()
 }
 

--- a/torrent/commonMain/TorrentDownloadSession.kt
+++ b/torrent/commonMain/TorrentDownloadSession.kt
@@ -20,7 +20,7 @@ public interface TorrentDownloadSession : AutoCloseable {
 
     public override fun close()
 
-    public suspend fun closeAndDelete() // TODO:  
+    public fun closeIfNotInUse()
 }
 
 public sealed class TorrentDownloadState {

--- a/torrent/commonMain/TorrentDownloadSessionImpl.kt
+++ b/torrent/commonMain/TorrentDownloadSessionImpl.kt
@@ -203,11 +203,13 @@ internal class TorrentDownloadSessionImpl(
 //                            handle.piecePriority(0, Priority.TOP_PRIORITY)
 //                            handle.piecePriority(pieces.lastIndex, Priority.TOP_PRIORITY)
 
-                        handle.setPieceDeadline(0, 0)
-                        handle.setPieceDeadline(pieces.lastIndex, 1)
+                        val firstIndex = pieces.first().pieceIndex
+                        val lastIndex = pieces.last().pieceIndex
+                        handle.setPieceDeadline(firstIndex, 0)
+                        handle.setPieceDeadline(lastIndex, 1)
 
-                        handle.setPieceDeadline(1, 2)
-                        handle.setPieceDeadline(2, 3)
+                        handle.setPieceDeadline(firstIndex + 1, 2)
+                        handle.setPieceDeadline(firstIndex + 2, 3)
                     }
                 }
 
@@ -216,7 +218,7 @@ internal class TorrentDownloadSessionImpl(
         }
 
         /**
-         * 与这个文件有关的 pieces
+         * 与这个文件有关的 pieces, sorted naturally by pieceIndex
          */
         private val pieces: SuspendLazy<List<Piece>> = SuspendLazy {
             val allPieces = this@TorrentDownloadSessionImpl.actualInfo.await().pieces

--- a/torrent/commonMain/TorrentDownloader.kt
+++ b/torrent/commonMain/TorrentDownloader.kt
@@ -319,12 +319,15 @@ internal class TorrentDownloaderImpl(
         }
 
         logger.info { "Fetching magnet: $uri" }
-        val data: ByteArray = try {
+        val data: ByteArray? = try {
             sessionManager.use {
                 fetchMagnet(uri, timeoutSeconds, magnetCacheDir)
             }
         } catch (e: InterruptedException) {
             throw MagnetTimeoutException(cause = e)
+        }
+        if (data == null) {
+            throw MagnetTimeoutException()
         }
         logger.info { "Fetched magnet: size=${data.size}" }
         return EncodedTorrentData(data)

--- a/torrent/commonMain/TorrentDownloader.kt
+++ b/torrent/commonMain/TorrentDownloader.kt
@@ -92,9 +92,9 @@ public interface TorrentDownloader : AutoCloseable {
 }
 
 public enum class FilePriority {
-    HIGH,
-    NORMAL,
     LOW,
+    NORMAL,
+    HIGH,
 }
 
 public class MagnetTimeoutException(
@@ -432,7 +432,7 @@ internal class TorrentDownloaderImpl(
 internal fun FilePriority.toLibtorrentPriority(): Priority = when (this) {
     FilePriority.HIGH -> Priority.TOP_PRIORITY
     FilePriority.NORMAL -> Priority.DEFAULT
-    FilePriority.LOW -> Priority.IGNORE
+    FilePriority.LOW -> Priority.LOW
 }
 
 public var SettingsPack.peerFingerprintString: String

--- a/torrent/commonMain/TorrentFileEntry.kt
+++ b/torrent/commonMain/TorrentFileEntry.kt
@@ -1,0 +1,80 @@
+package me.him188.ani.app.torrent
+
+import me.him188.ani.utils.io.SeekableInput
+import java.nio.file.Path
+
+/**
+ * 表示 BT 资源中的一个文件.
+ *
+ * 所有文件默认都没有开始下载, 需调用 [createHandle] 创建一个句柄, 并使用 [TorrentFileHandle.resume] 才会开始下载.
+ * 当句柄被关闭后, 该文件的下载也会被停止.
+ *
+ * @see TorrentDownloadSession
+ */
+public interface TorrentFileEntry {
+    /**
+     * 该文件的下载数据
+     */
+    public val stats: DownloadStats
+
+    /**
+     * 文件数据长度. 注意, 这不是文件在硬盘上的大小. 在硬盘上可能会略有差别.
+     */
+    public val length: Long
+
+    /**
+     * 在种子资源中的相对目录. 例如 `01.mp4`, `TV/01.mp4`
+     */
+    public val filePath: String
+
+    /**
+     * 创建一个句柄, 以用于下载文件.
+     */
+    public suspend fun createHandle(): TorrentFileHandle
+
+    /**
+     * Awaits until the hash is available
+     */
+    public suspend fun getFileHash(): String
+
+    /**
+     * Returns the hash if available, otherwise `null`
+     */
+    public fun getFileHashOrNull(): String? // TODO: 这个函数会在文件还没下载完成时也返回 
+
+    /**
+     * 绝对路径. 挂起直到文件路径可用 (即有任意一个 piece 下载完成时)
+     */
+    public suspend fun resolveFile(): Path
+
+    /**
+     * Opens the downloaded file as a [SeekableInput].
+     */
+    public suspend fun createInput(): SeekableInput
+}
+
+/**
+ * [TorrentFileEntry] 的下载控制器.
+ *
+ * 每个 [TorrentFileEntry] 可以有多个 [TorrentFileHandle], 仅当所有 [TorrentFileHandle] 都被关闭或 [pause] 后, 文件的下载才会被停止.
+ */
+public interface TorrentFileHandle : AutoCloseable {
+    public val entry: TorrentFileEntry
+
+    /**
+     * 恢复下载并设置优先级
+     * @throws IllegalStateException 当已经 [close] 时抛出
+     */
+    public suspend fun resume(priority: FilePriority = FilePriority.NORMAL)
+
+    /**
+     * 暂停下载
+     * @throws IllegalStateException 当已经 [close] 时抛出
+     */
+    public suspend fun pause()
+
+    /**
+     * 停止下载并关闭此 [TorrentFileHandle]. 后续将不能再 [resume] 或 [pause] 等.
+     */
+    public override fun close()
+}

--- a/torrent/commonMain/TorrentFileEntry.kt
+++ b/torrent/commonMain/TorrentFileEntry.kt
@@ -63,6 +63,9 @@ public interface TorrentFileHandle : AutoCloseable {
 
     /**
      * 恢复下载并设置优先级
+     *
+     * 注意, 设置低于 [FilePriority.NORMAL] 可能会导致下载速度缓慢
+     *
      * @throws IllegalStateException 当已经 [close] 时抛出
      */
     public suspend fun resume(priority: FilePriority = FilePriority.NORMAL)

--- a/torrent/commonMain/model/Piece.kt
+++ b/torrent/commonMain/model/Piece.kt
@@ -1,7 +1,9 @@
 package me.him188.ani.app.torrent.model
 
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.takeWhile
 import me.him188.ani.app.torrent.PieceState
 
@@ -11,6 +13,10 @@ public class Piece(
     public val offset: Long,
 ) {
     public val state: MutableStateFlow<PieceState> = MutableStateFlow(PieceState.READY)
+    public val downloadedBytes: Flow<Long>
+        get() = state.map {
+            if (it == PieceState.FINISHED) size else 0L
+        }
 
     public companion object {
         public fun buildPieces(

--- a/torrent/commonMain/model/Piece.kt
+++ b/torrent/commonMain/model/Piece.kt
@@ -13,8 +13,12 @@ public class Piece(
     public val state: MutableStateFlow<PieceState> = MutableStateFlow(PieceState.READY)
 
     public companion object {
-        public fun buildPieces(numPieces: Int, getPieceSize: (index: Int) -> Long): List<Piece> = buildList(numPieces) {
-            var pieceOffset = 0L
+        public fun buildPieces(
+            numPieces: Int,
+            initial: Long = 0L,
+            getPieceSize: (index: Int) -> Long,
+        ): List<Piece> = buildList(numPieces) {
+            var pieceOffset = initial
             for (i in 0 until numPieces) {
                 val pieceSize = getPieceSize(i)
                 val piece = Piece(

--- a/utils/coroutines/src/SuspendLazy.kt
+++ b/utils/coroutines/src/SuspendLazy.kt
@@ -43,6 +43,7 @@ class SuspendLazyImpl<T>(
             if (initialized) return value as T
             val initializer = initializer ?: error("initializer should not be null")
             value = initializer()
+            this.initializer = null // avoid memory leak since the initializer might hold reference to a resource
             initialized = true
         }
         return value as T

--- a/utils/coroutines/src/SuspendLazy.kt
+++ b/utils/coroutines/src/SuspendLazy.kt
@@ -1,5 +1,7 @@
 package me.him188.ani.utils.coroutines
 
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
@@ -15,6 +17,10 @@ interface SuspendLazy<T> {
      * When [get] is called the next time, the initializer is called again.
      */
     suspend fun get(): T
+}
+
+fun <T> SuspendLazy<T>.asFlow(): Flow<T> = flow {
+    emit(get())
 }
 
 fun <T> SuspendLazy(

--- a/utils/coroutines/src/flows/ResetOnEvery.kt
+++ b/utils/coroutines/src/flows/ResetOnEvery.kt
@@ -1,0 +1,42 @@
+package me.him188.ani.utils.coroutines.flows
+
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+
+/**
+ * 创建一个 flow, 当 [durationMillis] 时间内没有新的元素时, 会调用 [reset] 方法.
+ */
+fun <T> Flow<T>.resetStale(
+    durationMillis: Long,
+    reset: suspend FlowCollector<T>.() -> Unit,
+): Flow<T> {
+    val upstream = this
+    return channelFlow {
+        val collector: FlowCollector<T> = FlowCollector { value -> send(value) }
+        coroutineScope {
+            val time = object {
+                @Volatile
+                var value: Long = 0L
+            }
+            launch {
+                while (isActive) {
+                    delay(durationMillis)
+                    val now = System.currentTimeMillis()
+                    if (now - time.value >= durationMillis) {
+                        time.value = Long.MAX_VALUE
+                        reset(collector)
+                    }
+                }
+            }
+            upstream.collect {
+                time.value = System.currentTimeMillis()
+                send(it)
+            }
+        }
+    }
+}


### PR DESCRIPTION
现在可以正确按集数区分全集资源中的文件并播放. 用户操作上与以前没有区别. 可以补番啦

这些资源中的文件只会在请求时才会下载, 例如一个 01-12 的全集资源, 在播放 03 的时候才会去下载 03

close #135 

