### PR TITLE
optimize: bangumi search with old api.

### DIFF
--- a/data-sources/bangumi/src/BangumiPagedSource.kt
+++ b/data-sources/bangumi/src/BangumiPagedSource.kt
@@ -2,10 +2,12 @@ package me.him188.ani.datasources.bangumi
 
 import me.him188.ani.datasources.api.paging.AbstractPageBasedPagedSource
 import me.him188.ani.datasources.api.subject.Subject
+import me.him188.ani.datasources.api.subject.SubjectImages
 import me.him188.ani.datasources.api.subject.SubjectSearchQuery
 import me.him188.ani.datasources.api.subject.SubjectType
+import me.him188.ani.datasources.bangumi.models.subjects.BangumiLegacySubject
+import me.him188.ani.datasources.bangumi.models.subjects.BangumiSubjectImageSize
 import me.him188.ani.datasources.bangumi.models.subjects.BangumiSubjectType
-import me.him188.ani.datasources.bangumi.models.subjects.toSubject
 
 class BangumiPagedSource(
     private val client: BangumiClient,
@@ -14,20 +16,45 @@ class BangumiPagedSource(
 ) : AbstractPageBasedPagedSource<Subject>() {
 
     override suspend fun nextPageImpl(page: Int): List<Subject> {
-        val paged = client.subjects.searchSubjectByKeywords(
+        val paged = client.subjects.searchSubjectsByKeywordsWithOldApi(
             query.keyword,
-            offset = page * pageSize,
-            // 才有 rating
-            limit = pageSize,
-            types = listOf(convertType()),
+            convertType(),
+            null,
+            page * pageSize,
+            pageSize
         )
         if (!paged.hasMore) {
             noMorePages()
         }
-        return paged.page.map { it.toSubject() }
+        return paged.page
+            .map {convert2Subject(it)}
+    }
+
+    private fun convert2Subject(legaSub: BangumiLegacySubject):Subject {
+        return Subject(
+            id = legaSub.id,
+            originalName = legaSub.originalName,
+            chineseName = legaSub.chineseName,
+            score = 0.0,
+            rank = legaSub.rank.let { 0 },
+            tags = listOf(),
+            sourceUrl = legaSub.url.let { "" },
+            images = SubjectImages(
+                landscapeCommon = BangumiClientImpl.getSubjectImageUrl(
+                    legaSub.id,
+                    BangumiSubjectImageSize.MEDIUM
+                ),
+                largePoster = BangumiClientImpl.getSubjectImageUrl(
+                    legaSub.id,
+                    BangumiSubjectImageSize.LARGE
+                ),
+            ),
+            summary = legaSub.summary,
+        )
     }
 
     private fun convertType() = when (query.type) {
         SubjectType.ANIME -> BangumiSubjectType.ANIME
-    }
+    }    
+   
 }

--- a/data-sources/bangumi/src/client/BangumiClientSubjects.kt
+++ b/data-sources/bangumi/src/client/BangumiClientSubjects.kt
@@ -2,6 +2,7 @@ package me.him188.ani.datasources.bangumi.client
 
 import me.him188.ani.datasources.api.paging.Paged
 import me.him188.ani.datasources.bangumi.models.search.BangumiSort
+import me.him188.ani.datasources.bangumi.models.subjects.BangumiLegacySubject
 import me.him188.ani.datasources.bangumi.models.subjects.BangumiSubject
 import me.him188.ani.datasources.bangumi.models.subjects.BangumiSubjectDetails
 import me.him188.ani.datasources.bangumi.models.subjects.BangumiSubjectImageSize
@@ -31,6 +32,29 @@ interface BangumiClientSubjects {
         ranks: List<String>? = null,
         nsfw: Boolean? = null,
     ): Paged<BangumiSubject>
+
+    /**
+     * Search bangumi subjects by old api.
+     *
+     * @see <https://github.com/bangumi/server>
+     * @see <https://bangumi.github.io/api/>
+     *
+     * @param keyword subject keyword, such as name.
+     * @param type bangumi subject type, default search all types when it is null.
+     * @param responseGroup return the data size which default is small, available values : [small, medium, large], default value is small.
+     * @param start start page, default is first page.
+     * @param maxResults max results in page, max is 25.
+     * @see BangumiSubjectType
+     * @see BangumiSubjectImageSize
+     *
+     */
+    suspend fun searchSubjectsByKeywordsWithOldApi(
+        keyword: String,
+        type: BangumiSubjectType?,
+        responseGroup: BangumiSubjectImageSize?,
+        start: Int?,
+        maxResults: Int?
+    ): Paged<BangumiLegacySubject>
 
     suspend fun getSubjectById(
         id: Int,

--- a/data-sources/bangumi/src/models/subjects/BangumiLegacySubject.kt
+++ b/data-sources/bangumi/src/models/subjects/BangumiLegacySubject.kt
@@ -1,0 +1,34 @@
+package me.him188.ani.datasources.bangumi.models.subjects
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import me.him188.ani.datasources.bangumi.BangumiRating
+
+@Serializable
+data class BangumiLegacySubject(
+    val id: Int,
+    val type: BangumiSubjectType,
+    @SerialName("name") val originalName: String, // 日文
+    @SerialName("name_cn") val chineseName: String, // 中文
+    val summary: String, // can be very long
+    @SerialName("air_date") val airDate: String, // "2002-04-02"
+    @SerialName("air_weekday") val airWeekday: Int,
+    @SerialName("images") val images: BangumiSubjectImages,
+    val eps: Int = 1, // 话数
+    @SerialName("eps_count") val epsCount: Int = 1, // 话数
+    val rating: BangumiRating? = null,
+    val collection: BangumiCollection? = null,
+
+    // small fields
+    val tags: List<BangumiSubjectTag>? = null,
+
+    // medium fields
+    val url: String? = "",       // 条目地址
+    val rank: Int? = 0,         // 排名
+    val crt: String? = "",       // 角色信息
+    val staff: String? = "",     // 制作人员信息
+    
+    // large fields
+    val topic: String? = "",     // 讨论版
+    val blog: String? = "",      // 评论日志
+)


### PR DESCRIPTION
使用旧的查询API替换目前问题很多的新的查询API

从

`/v0/search/subjects`

到

`/search/subject/{subjectId}`


具体API请看：<https://bangumi.github.io/api/>