### PR TITLE
fix: screen out the episode positive that group is MAIN when the sequence is repeated for ikaros media source.

### DIFF
--- a/data-sources/ikaros/src/IkarosClient.kt
+++ b/data-sources/ikaros/src/IkarosClient.kt
@@ -75,7 +75,7 @@ class IkarosClient(
     fun subjectDetails2SizedSource(subjectDetails: IkarosSubjectDetails, seq: Int): SizedSource<MediaMatch> {
         val episodes = subjectDetails.episodes
         val mediaMatchs = mutableListOf<MediaMatch>()
-        val episode = episodes.find { ep -> ep.sequence == seq }
+        val episode = episodes.find { ep -> ep.sequence == seq && "MAIN" == ep.group }
         if (episode?.resources != null && episode.resources.isNotEmpty()) {
             for (epRes in episode.resources) {
                 val media = epRes?.let {

--- a/data-sources/ikaros/src/models/IkarosEpisodeDetails.kt
+++ b/data-sources/ikaros/src/models/IkarosEpisodeDetails.kt
@@ -12,5 +12,6 @@ data class IkarosEpisodeDetails(
     val description: String,
     @SerialName("air_time") val airTime: String?,
     val sequence: Int,
-    val resources: List<IkarosEpisodeResource?>? = null
+    val resources: List<IkarosEpisodeResource?>? = null,
+    val group: String,
 )


### PR DESCRIPTION
当一个条目有多种剧集时，筛选出其中的正片剧集进行匹配。

![image](https://github.com/open-ani/ani/assets/46225881/1cee2f8d-225d-4c26-92cd-2c204daeb239)
