### PR TITLE
fix: 无法正确设置 qBittorrent 分类的问题

### DIFF
--- a/app/shared/pages/settings/common/tabs/media/TorrentEngineGroup.kt
+++ b/app/shared/pages/settings/common/tabs/media/TorrentEngineGroup.kt
@@ -163,7 +163,7 @@ private fun SettingsScope.QBGroup(vm: MediaSettingsViewModel) {
             onValueChangeCompleted = {
                 vm.qBittorrentConfig.update(
                     config.copy(
-                        clientConfig = clientConfig.copy(password = it)
+                        clientConfig = clientConfig.copy(category = it)
                     )
                 )
             },


### PR DESCRIPTION
无法设置分类，每次设置分类都会变成修改密码。对编译调试不太了解，并没有在本地测试，就改一个字段应该不会出什么问题？