### PR TITLE
增加调试模式

### DIFF
--- a/app/android/src/main/kotlin/activity/MainActivity.kt
+++ b/app/android/src/main/kotlin/activity/MainActivity.kt
@@ -25,9 +25,11 @@ import android.os.Build
 import android.os.Bundle
 import android.view.WindowInsets
 import android.view.WindowInsetsController
+import android.widget.Toast
 import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.core.app.ActivityCompat
 import androidx.core.view.WindowCompat
 import androidx.lifecycle.lifecycleScope
@@ -39,6 +41,8 @@ import me.him188.ani.app.platform.notification.NotifManager
 import me.him188.ani.app.session.BangumiAuthorizationConstants
 import me.him188.ani.app.session.OAuthResult
 import me.him188.ani.app.session.SessionManager
+import me.him188.ani.app.ui.foundation.widgets.LocalToaster
+import me.him188.ani.app.ui.foundation.widgets.Toaster
 import me.him188.ani.app.ui.main.AniApp
 import me.him188.ani.app.ui.main.AniAppContent
 import me.him188.ani.utils.logging.error
@@ -141,7 +145,13 @@ class MainActivity : AniComponentActivity() {
 //                        }
 //                    }
 //                }
-                AniAppContent(aniNavigator)
+                CompositionLocalProvider(LocalToaster provides object : Toaster {
+                    override fun toast(text: String) {
+                        Toast.makeText(this@MainActivity, text, Toast.LENGTH_LONG).show()
+                    }
+                }) {
+                    AniAppContent(aniNavigator)
+                }
             }
         }
 

--- a/app/shared/src/commonMain/kotlin/data/models/DebugSettings.kt
+++ b/app/shared/src/commonMain/kotlin/data/models/DebugSettings.kt
@@ -1,0 +1,18 @@
+package me.him188.ani.app.data.models
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.Stable
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
+
+@Serializable
+@Immutable
+data class DebugSettings(
+    val enabled: Boolean = false,
+    @Suppress("PropertyName") @Transient val _placeHolder: Int = 0,
+) {
+    companion object {
+        @Stable
+        val Default = DebugSettings()
+    }
+}

--- a/app/shared/src/commonMain/kotlin/data/repositories/SettingsRepository.kt
+++ b/app/shared/src/commonMain/kotlin/data/repositories/SettingsRepository.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.json.Json
 import me.him188.ani.app.data.models.DanmakuSettings
+import me.him188.ani.app.data.models.DebugSettings
 import me.him188.ani.app.data.models.MediaCacheSettings
 import me.him188.ani.app.data.models.MediaSelectorSettings
 import me.him188.ani.app.data.models.OneshotActionConfig
@@ -55,6 +56,8 @@ interface SettingsRepository {
     val qBittorrentConfig: Settings<QBittorrentConfig>
 
     val oneshotActionConfig: Settings<OneshotActionConfig>
+
+    val debugSettings: Settings<DebugSettings>
 }
 
 @Stable
@@ -167,6 +170,12 @@ class PreferencesRepositoryImpl(
         "oneshotActionConfig",
         OneshotActionConfig.serializer(),
         default = { OneshotActionConfig.Default }
+    )
+
+    override val debugSettings: Settings<DebugSettings> = SerializablePreference(
+        "debugSettings",
+        DebugSettings.serializer(),
+        default = { DebugSettings.Default }
     )
 
     private companion object {

--- a/app/shared/src/commonMain/kotlin/ui/foundation/widgets/Toast.kt
+++ b/app/shared/src/commonMain/kotlin/ui/foundation/widgets/Toast.kt
@@ -1,0 +1,101 @@
+package me.him188.ani.app.ui.foundation.widgets
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.layout
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import me.him188.ani.app.tools.MonoTasker
+import me.him188.ani.app.ui.foundation.AbstractViewModel
+import me.him188.ani.utils.coroutines.update
+import moe.tlaster.precompose.viewmodel.viewModelScope
+import kotlin.math.max
+import kotlin.math.min
+
+@Stable
+val LocalToaster: ProvidableCompositionLocal<Toaster> = staticCompositionLocalOf {
+    error("No LocalToaster provided")
+}
+
+@Stable
+interface Toaster {
+    fun toast(text: String)
+}
+
+class ToastViewModel : AbstractViewModel() {
+    private val tasker = MonoTasker(viewModelScope)
+
+    val showing = MutableStateFlow(false)
+    val content = MutableStateFlow("")
+
+    fun show(text: String) {
+        showing.update { true }
+        content.update { text }
+
+        tasker.launch {
+            delay(4000L)
+            showing.emit(false)
+        }
+    }
+}
+
+@Composable
+fun Toast(
+    showing: Boolean,
+    content: String
+) = BoxWithConstraints(Modifier.fillMaxSize()) box@{
+    val px640dp = with(LocalDensity.current) { 640.dp.roundToPx() }
+    val px100dp = with(LocalDensity.current) { 100.dp.roundToPx() }
+
+    val minToastWidth = with(LocalDensity.current) { px100dp + 60.dp.roundToPx() * 2 }
+    val maxToastWidth = max(minToastWidth, min(constraints.maxWidth, px640dp))
+
+    AnimatedVisibility(
+        visible = showing,
+        enter = fadeIn(tween(350, easing = LinearEasing)),
+        exit = fadeOut(tween(350, easing = LinearEasing)),
+        modifier = Modifier.layout { measurable, constraints ->
+            val rawWidth = measurable.measure(constraints.copy(minWidth = 0, maxWidth = Int.MAX_VALUE)).width
+
+            val placeable = measurable.measure(
+                constraints.copy(minWidth = min(rawWidth, minToastWidth), maxWidth = maxToastWidth, minHeight = 0)
+            )
+
+            val x = max(this@box.constraints.maxWidth - placeable.width, 0) / 2
+            val y = constraints.maxHeight - placeable.height - px100dp
+
+            layout(placeable.width, placeable.height) {
+                placeable.place(x, y, 100f)
+            }
+        }
+    ) {
+        Surface(
+            modifier = Modifier.padding(horizontal = 60.dp),
+            shape = RoundedCornerShape(15.dp),
+            color = Color.Black.copy(alpha = 0.7f)
+        ) {
+            Text(
+                text = content,
+                color = Color.White,
+                modifier = Modifier.padding(horizontal = 20.dp, vertical = 10.dp)
+            )
+        }
+    }
+}

--- a/app/shared/src/commonMain/kotlin/ui/main/AniAppContentPortrait.kt
+++ b/app/shared/src/commonMain/kotlin/ui/main/AniAppContentPortrait.kt
@@ -79,7 +79,7 @@ fun AniAppContentPortrait(
                 SettingsPage(
                     Modifier.fillMaxSize(),
                     initialTab = initialTab,
-                    allowBack = backStackEntry.query("back") ?: false
+                    allowBack = backStackEntry.query("back") ?: false,
                 )
             }
             scene("/caches") {

--- a/app/shared/src/commonMain/kotlin/ui/profile/SettingsViewModel.kt
+++ b/app/shared/src/commonMain/kotlin/ui/profile/SettingsViewModel.kt
@@ -1,22 +1,23 @@
 package me.him188.ani.app.ui.profile
 
 import androidx.compose.runtime.getValue
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 import me.him188.ani.app.data.models.DebugSettings
 import me.him188.ani.app.data.repositories.SettingsRepository
+import me.him188.ani.app.tools.MonoTasker
 import me.him188.ani.app.ui.settings.framework.AbstractSettingsViewModel
 import moe.tlaster.precompose.viewmodel.viewModelScope
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import java.util.LinkedList
 
-class SettingsViewModel : AbstractSettingsViewModel(), KoinComponent {
+class SettingsViewModel(
+    private val triggerOnEnableDebugMode: () -> Unit = {}
+) : AbstractSettingsViewModel(), KoinComponent {
     private val settingsRepository by inject<SettingsRepository>()
     private val debugTriggerRecord = LinkedList<Long>()
 
-    private var clearJob: Job? = null
+    private val tasker = MonoTasker(viewModelScope)
 
     private val _debugSettings by settings(
         settingsRepository.debugSettings,
@@ -35,12 +36,11 @@ class SettingsViewModel : AbstractSettingsViewModel(), KoinComponent {
 
     fun triggerDebugMode() {
         if (debugSettings.enabled) return
-        cancelClearJob()
-        clearJob = viewModelScope.launch { clearTriggerRecord() }
+        tasker.launch { clearTriggerRecord() }
 
         if (debugTriggerRecord.size == 5) {
             debugTriggerRecord.clear()
-            cancelClearJob()
+            tasker.cancel()
         }
         debugTriggerRecord.push(System.currentTimeMillis())
 
@@ -50,12 +50,8 @@ class SettingsViewModel : AbstractSettingsViewModel(), KoinComponent {
         ) {
             debugTriggerRecord.clear()
             _debugSettings.update(debugSettings.copy(enabled = true))
-            cancelClearJob()
+            triggerOnEnableDebugMode()
+            tasker.cancel()
         }
-    }
-
-    private fun cancelClearJob() {
-        clearJob?.cancel()
-        clearJob = null
     }
 }

--- a/app/shared/src/commonMain/kotlin/ui/profile/SettingsViewModel.kt
+++ b/app/shared/src/commonMain/kotlin/ui/profile/SettingsViewModel.kt
@@ -1,0 +1,61 @@
+package me.him188.ani.app.ui.profile
+
+import androidx.compose.runtime.getValue
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import me.him188.ani.app.data.models.DebugSettings
+import me.him188.ani.app.data.repositories.SettingsRepository
+import me.him188.ani.app.ui.settings.framework.AbstractSettingsViewModel
+import moe.tlaster.precompose.viewmodel.viewModelScope
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+import java.util.LinkedList
+
+class SettingsViewModel : AbstractSettingsViewModel(), KoinComponent {
+    private val settingsRepository by inject<SettingsRepository>()
+    private val debugTriggerRecord = LinkedList<Long>()
+
+    private var clearJob: Job? = null
+
+    private val _debugSettings by settings(
+        settingsRepository.debugSettings,
+        placeholder = DebugSettings(_placeHolder = -1)
+    )
+    val debugSettings by _debugSettings
+
+    init {
+        debugTriggerRecord.clear()
+    }
+
+    private suspend fun clearTriggerRecord() {
+        delay(5000L)
+        debugTriggerRecord.clear()
+    }
+
+    fun triggerDebugMode() {
+        if (debugSettings.enabled) return
+        cancelClearJob()
+        clearJob = viewModelScope.launch { clearTriggerRecord() }
+
+        if (debugTriggerRecord.size == 5) {
+            debugTriggerRecord.clear()
+            cancelClearJob()
+        }
+        debugTriggerRecord.push(System.currentTimeMillis())
+
+        if (
+            debugTriggerRecord.size == 5 &&
+            debugTriggerRecord.zipWithNext().all { (prev, next) -> next - prev < 1000L }
+        ) {
+            debugTriggerRecord.clear()
+            _debugSettings.update(debugSettings.copy(enabled = true))
+            cancelClearJob()
+        }
+    }
+
+    private fun cancelClearJob() {
+        clearJob?.cancel()
+        clearJob = null
+    }
+}

--- a/app/shared/src/commonMain/kotlin/ui/settings/SettingsPage.kt
+++ b/app/shared/src/commonMain/kotlin/ui/settings/SettingsPage.kt
@@ -35,6 +35,7 @@ import me.him188.ani.app.platform.isMobile
 import me.him188.ani.app.ui.foundation.layout.isShowLandscapeUI
 import me.him188.ani.app.ui.foundation.pagerTabIndicatorOffset
 import me.him188.ani.app.ui.foundation.rememberViewModel
+import me.him188.ani.app.ui.foundation.widgets.LocalToaster
 import me.him188.ani.app.ui.foundation.widgets.TopAppBarGoBackButton
 import me.him188.ani.app.ui.profile.SettingsViewModel
 import me.him188.ani.app.ui.settings.framework.components.SettingsScope
@@ -69,7 +70,12 @@ fun SettingsPage(
     contentPadding: PaddingValues = PaddingValues(0.dp),
     allowBack: Boolean = !isShowLandscapeUI(),
 ) {
-    val vm = rememberViewModel { SettingsViewModel() }
+    val toaster = LocalToaster.current
+    val vm = rememberViewModel {
+        SettingsViewModel(
+            triggerOnEnableDebugMode = { toaster.toast("调试模式已开启") }
+        )
+    }
     
     Scaffold(
         modifier,

--- a/app/shared/src/commonMain/kotlin/ui/settings/tabs/AboutTab.kt
+++ b/app/shared/src/commonMain/kotlin/ui/settings/tabs/AboutTab.kt
@@ -1,6 +1,7 @@
 package me.him188.ani.app.ui.settings.tabs
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
@@ -92,6 +93,7 @@ private const val MIKAN = "https://mikanime.tv/"
 fun AboutTab(
     vm: AboutTabViewModel = rememberViewModel { AboutTabViewModel() },
     modifier: Modifier = Modifier,
+    onTriggerDebugMode: () -> Unit = { },
 ) {
     val context by rememberUpdatedState(LocalContext.current)
 
@@ -184,7 +186,16 @@ fun AboutTab(
         }
 
         Group(
-            title = { Text("调试信息") },
+            title = {
+                Text(
+                    text = "调试信息",
+                    modifier = Modifier.clickable(
+                        interactionSource = remember { MutableInteractionSource() },
+                        indication = null,
+                        onClick = onTriggerDebugMode
+                    )
+                )
+            },
             description = { Text("在反馈问题时附上日志可能有用") }
         ) {
             Column(Modifier.padding(horizontal = 16.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {

--- a/app/shared/src/commonMain/kotlin/ui/settings/tabs/DebugTab.kt
+++ b/app/shared/src/commonMain/kotlin/ui/settings/tabs/DebugTab.kt
@@ -1,0 +1,51 @@
+package me.him188.ani.app.ui.settings.tabs
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import me.him188.ani.app.data.models.DebugSettings
+import me.him188.ani.app.data.repositories.SettingsRepository
+import me.him188.ani.app.ui.external.placeholder.placeholder
+import me.him188.ani.app.ui.foundation.rememberViewModel
+import me.him188.ani.app.ui.settings.SettingsTab
+import me.him188.ani.app.ui.settings.framework.AbstractSettingsViewModel
+import me.him188.ani.app.ui.settings.framework.components.SwitchItem
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+
+class DebugViewModel : AbstractSettingsViewModel(), KoinComponent {
+    private val settingsRepository by inject<SettingsRepository>()
+
+    val debugSettings by settings(
+        settingsRepository.debugSettings,
+        placeholder = DebugSettings(_placeHolder = -1)
+    )
+}
+
+@Composable
+fun DebugTab(
+    modifier: Modifier = Modifier,
+    onDisableDebugMode: () -> Unit = {}
+) {
+    val vm = rememberViewModel { DebugViewModel() }
+    val debugSettings by vm.debugSettings
+
+    SettingsTab(modifier) {
+        Group(
+            title = { Text("调试模式状态") },
+            useThinHeader = true
+        ) {
+            SwitchItem(
+                checked = debugSettings.enabled,
+                onCheckedChange = { checked ->
+                    if (!checked) onDisableDebugMode()
+                    vm.debugSettings.update(debugSettings.copy(enabled = checked))
+                },
+                title = { Text("调试模式") },
+                Modifier.placeholder(vm.debugSettings.loading),
+                description = { Text("已开启调试模式，点击关闭") },
+            )
+        }
+    }
+}


### PR DESCRIPTION
类似 Android 的开发者模式，开启调试模式可以设置高级选项。

在 设置->关于 界面连点 5 次调试信息标题开启调试模式。开启调试模式后显示新的设置 Tab。

![image](https://github.com/open-ani/ani/assets/45701251/dd04201e-a120-42a8-a8ab-4813f15caa34)

还差开启调试模式的提示，在 Android 用 Toast，在 JVM 打算实现一个类似的东西，也包含在这个 PR 中。