### PR TITLE
fix: allow null value for IkarosEpisodeDetails#description

### DIFF
--- a/data-sources/ikaros/src/models/IkarosEpisodeDetails.kt
+++ b/data-sources/ikaros/src/models/IkarosEpisodeDetails.kt
@@ -9,7 +9,7 @@ data class IkarosEpisodeDetails(
     @SerialName("subject_id") val subjectId: Long,
     val name: String,
     @SerialName("name_cn") val nameCn: String?,
-    val description: String,
+    val description: String?,
     @SerialName("air_time") val airTime: String?,
     val sequence: Int,
     val resources: List<IkarosEpisodeResource?>? = null,


### PR DESCRIPTION
剧集详情的`描述`字段不是必须的，可能为空
![image](https://github.com/user-attachments/assets/9391ce0f-2070-4150-9b90-7ced4a9aeaab)

当剧集详情为空时，未修改前会导致数据源的JSON解析异常