### PR TITLE
fix: incorrect subtitle id check logic.

### DIFF
--- a/app/shared/video-player/desktop/ui/VideoPlayer.desktop.kt
+++ b/app/shared/video-player/desktop/ui/VideoPlayer.desktop.kt
@@ -323,12 +323,12 @@ class VlcjVideoPlayerState(parentCoroutineContext: CoroutineContext) : PlayerSta
                         logger.error { "Invalid subtitle track id: ${track.id}" }
                         return@collect
                     }
-                    val count = player.subpictures().trackCount()
-                    if (id > count) {
-                        logger.error { "Invalid subtitle track id: $id, count: $count" }
+                    val subTrackIds = player.subpictures().trackDescriptions().map { it.id() }
+                    logger.info { "All ids: $subTrackIds" }
+                    if (!subTrackIds.contains(id)) {
+                        logger.error { "Invalid subtitle track id: $id" }
                         return@collect
                     }
-                    logger.info { "All ids: ${player.subpictures().trackDescriptions().map { it.id() }}" }
                     player.subpictures().setTrack(id)
                     logger.info { "Set subtitle track to $id (${track.labels.firstOrNull()})" }
                 } catch (e: Throwable) {


### PR DESCRIPTION
字幕ID并不是连续的，检验ID的逻辑有问题，导致外挂字幕选择失效。
```
VlcjVideoPlayerState: All ids: [-1, 4, 5, 6]
```