### PR TITLE
fix danmaku

### DIFF
--- a/danmaku/ui/commonMain/FixedDanmakuTrackState.kt
+++ b/danmaku/ui/commonMain/FixedDanmakuTrackState.kt
@@ -68,7 +68,7 @@ class FixedDanmakuTrackState(
         }
 
         val danmaku = channel.receiveCatching().getOrNull() ?: return
-        place(danmaku, frameTime)
+        place(danmaku, System.currentTimeMillis())
     }
 
     /**


### PR DESCRIPTION
receiveCatching会挂起，导致place的sendTime是receiveCatching之前的时间点
fix #511 