### PR TITLE
修复 TimeFormatterTest.kt 中的 testUsingFormatter() 用例

### DIFF
--- a/app/shared/src/desktopTest/kotlin/tools/TimeFormatterTest.kt
+++ b/app/shared/src/desktopTest/kotlin/tools/TimeFormatterTest.kt
@@ -1,6 +1,9 @@
 package me.him188.ani.app.tools
 
 import kotlinx.datetime.Instant
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toInstant
+import kotlinx.datatime.toLocalDataTime
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.format.char
 import kotlin.test.Test
@@ -78,6 +81,8 @@ class TimeFormatterTest {
     @Test
     fun testUsingFormatter() {
         val timestamp = Instant.parse("2019-12-30T10:00:00Z")
+            .toLocalDataTime(TimeZone.UTC)
+            .toInstant(TimeZone.currentSystemDefault())
         assertEquals("2019-12-30 10:00:00", timeFormatter.format(timestamp))
     }
 }


### PR DESCRIPTION
修复因时区问题导致的解析结果不匹配

这是对 issue https://github.com/open-ani/ani/issues/679 的解决方案

在 Instant.parse 可以得知如果 parse的第二个参数 `format` 没有指定，会默认使用 `DateTimeComponents. Formats. ISO_DATE_TIME_OFFSET`。

这会导致在解析 2019-12-30T10:00:00Z 时会解析为零时区时间，而我尝试转换为东八区时间也就是修改为 2019-12-30T10:00:00+08:00，成功通过测试。所以应该只需要转换一下区时即可。

另外，我在 `app/shared/src/commonMain/kotlin/tools/TimeFormatter.kt` 下发现 `TimeFormatter.format` 的实现是做了时区的转换的：
```
    fun format(instant: Instant, showTime: Boolean = true): String {
        ......
            in -86400 * 2..<-86400 -> "${differenceInSeconds / 86400} 天后"
            else -> getFormatter(showTime).format(instant.toLocalDateTime(TimeZone.currentSystemDefault()))
        }
    }
```

大概是写test的时候忘记了吧 😆 ()