### PR TITLE
Configure Android Instrumented test

### DIFF
--- a/app/shared/src/androidInstrumentedTest/kotlin/package.kt
+++ b/app/shared/src/androidInstrumentedTest/kotlin/package.kt
@@ -1,0 +1,1 @@
+package me.him188.ani.app

--- a/buildSrc/src/main/kotlin/ani-mpp-lib-targets.gradle.kts
+++ b/buildSrc/src/main/kotlin/ani-mpp-lib-targets.gradle.kts
@@ -1,7 +1,10 @@
 import com.android.build.api.dsl.LibraryExtension
 import org.jetbrains.compose.ComposeExtension
 import org.jetbrains.compose.ComposePlugin
+import org.jetbrains.compose.ExperimentalComposeLibrary
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSetTree
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 /*
@@ -38,7 +41,10 @@ configure<KotlinMultiplatformExtension> {
     iosSimulatorArm64() // to run tests
     if (android != null) {
         jvm("desktop")
-        androidTarget()
+        androidTarget {
+            @OptIn(ExperimentalKotlinGradlePluginApi::class)
+            instrumentedTestVariant.sourceSetTree.set(KotlinSourceSetTree.instrumentedTest)
+        }
 
         applyDefaultHierarchyTemplate {
             common {
@@ -81,7 +87,31 @@ configure<KotlinMultiplatformExtension> {
         }
     }
     sourceSets.commonTest.dependencies {
+        // https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-test.html#writing-and-running-tests-with-compose-multiplatform
+        if (composeExtension != null) {
+            val compose = ComposePlugin.Dependencies(project)
+            @OptIn(ExperimentalComposeLibrary::class)
+            implementation(compose.uiTest)
+        }
         implementation(project(":utils:testing"))
+    }
+
+//    if (composeExtension != null) {
+//        sourceSets.getByName("desktopMain").dependencies {
+//            val compose = ComposePlugin.Dependencies(project)
+//            implementation(compose.desktop.uiTestJUnit4)
+//        }
+//    }
+    
+
+    if (android != null) {
+        sourceSets.androidInstrumentedTest.dependencies {
+            //https://developer.android.com/develop/ui/compose/testing#setup
+            implementation("androidx.compose.ui:ui-test-junit4-android:1.6.8")
+        }
+        dependencies {
+            "debugImplementation"("androidx.compose.ui:ui-test-manifest:1.6.8")
+        }
     }
 }
 
@@ -123,6 +153,7 @@ if (android != null) {
         compileSdk = getIntProperty("android.compile.sdk")
         defaultConfig {
             minSdk = getIntProperty("android.min.sdk")
+            testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         }
         buildTypes.getByName("release") {
             isMinifyEnabled = false // shared 不能 minify, 否则构建 app 会失败

--- a/buildSrc/src/main/kotlin/build.kt
+++ b/buildSrc/src/main/kotlin/build.kt
@@ -219,7 +219,6 @@ fun Project.configureKotlinTestSettings() {
                             // Android uses JUnit4
                             sourceSet.dependencies {
                                 implementation(kotlin("test"))?.because(b)
-                                implementation(kotlin("test-annotations-common"))?.because(b)
                                 implementation("junit:junit:4.13")?.because(b)
                                 implementation(kotlin("test-junit"))?.because(b)
                             }

--- a/buildSrc/src/main/kotlin/build.kt
+++ b/buildSrc/src/main/kotlin/build.kt
@@ -202,18 +202,27 @@ fun Project.configureKotlinTestSettings() {
                     .find { it.name == sourceSet.name.substringBeforeLast("Main").substringBeforeLast("Test") }
 
                 if (sourceSet.name.contains("test", ignoreCase = true)) {
-                    if (isJvmFinalTarget(target)) {
-                        // For android, this should be done differently. See Android.kt
-                        sourceSet.configureJvmTest(b)
-                    } else {
-                        if (sourceSet.name == "commonTest") {
+                    when {
+                        target?.platformType == KotlinPlatformType.jvm -> {
+                            // For android, this should be done differently. See Android.kt
+                            sourceSet.configureJvmTest(b)
+                        }
+
+                        sourceSet.name == "commonTest" -> {
                             sourceSet.dependencies {
                                 implementation(kotlin("test"))?.because(b)
                                 implementation(kotlin("test-annotations-common"))?.because(b)
                             }
-                        } else {
-                            // can be an Android sourceSet
-                            // Do not even add "kotlin-test" for Android sourceSets. IDEA can't resolve them on sync
+                        }
+
+                        target?.platformType == KotlinPlatformType.androidJvm -> {
+                            // Android uses JUnit4
+                            sourceSet.dependencies {
+                                implementation(kotlin("test"))?.because(b)
+                                implementation(kotlin("test-annotations-common"))?.because(b)
+                                implementation("junit:junit:4.13")?.because(b)
+                                implementation(kotlin("test-junit"))?.because(b)
+                            }
                         }
                     }
                 }
@@ -221,9 +230,6 @@ fun Project.configureKotlinTestSettings() {
         }
     }
 }
-
-private fun isJvmFinalTarget(target: KotlinTarget?) =
-    target?.platformType == KotlinPlatformType.jvm
 
 fun KotlinSourceSet.configureJvmTest(because: String) {
     dependencies {


### PR DESCRIPTION
instrumentedTest 使用 JUnit 4, 是一个独立源集, 即不会跑 commonTest 也不会跑 androidUnitTest. 

commonTest 层级架构不包含 instrumentedTest, 只包含 desktopTest, androidUnitTest, iosSimulatorArm64Test.

为了后面 compose ui test. 需要本机装有模拟器或者 ADB 连接真机才可以跑 instrumentedTest.

CC @StageGuard 

