### PR TITLE
在 PC 播放器使用 native skia 渲染

### DIFF
--- a/app/shared/video-player/src/desktopMain/kotlin/ui/SkiaBitmapVideoSurface.kt
+++ b/app/shared/video-player/src/desktopMain/kotlin/ui/SkiaBitmapVideoSurface.kt
@@ -1,0 +1,82 @@
+package me.him188.ani.app.videoplayer.ui
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asComposeImageBitmap
+import org.jetbrains.skia.Bitmap
+import org.jetbrains.skia.ColorAlphaType
+import org.jetbrains.skia.ColorType
+import org.jetbrains.skia.ImageInfo
+import uk.co.caprica.vlcj.player.base.MediaPlayer
+import uk.co.caprica.vlcj.player.embedded.videosurface.CallbackVideoSurface
+import uk.co.caprica.vlcj.player.embedded.videosurface.VideoSurface
+import uk.co.caprica.vlcj.player.embedded.videosurface.VideoSurfaceAdapters
+import uk.co.caprica.vlcj.player.embedded.videosurface.callback.BufferFormat
+import uk.co.caprica.vlcj.player.embedded.videosurface.callback.BufferFormatCallback
+import uk.co.caprica.vlcj.player.embedded.videosurface.callback.RenderCallback
+import uk.co.caprica.vlcj.player.embedded.videosurface.callback.format.RV32BufferFormat
+import java.nio.ByteBuffer
+import javax.swing.SwingUtilities
+
+class SkiaBitmapVideoSurface : VideoSurface(VideoSurfaceAdapters.getVideoSurfaceAdapter()) {
+
+    private val videoSurface = SkiaBitmapVideoSurface()
+    private lateinit var imageInfo: ImageInfo
+    private lateinit var frameBytes: ByteArray
+    private val skiaBitmap: Bitmap = Bitmap()
+    private val composeBitmap = mutableStateOf<ImageBitmap?>(null)
+
+    val bitmap by composeBitmap
+
+    fun clearBitmap() {
+        composeBitmap.value = null
+    }
+
+    override fun attach(mediaPlayer: MediaPlayer) {
+        videoSurface.attach(mediaPlayer)
+    }
+
+    private inner class SkiaBitmapBufferFormatCallback : BufferFormatCallback {
+        private var sourceWidth: Int = 0
+        private var sourceHeight: Int = 0
+
+        override fun getBufferFormat(sourceWidth: Int, sourceHeight: Int): BufferFormat {
+            this.sourceWidth = sourceWidth
+            this.sourceHeight = sourceHeight
+            return RV32BufferFormat(sourceWidth, sourceHeight)
+        }
+
+        override fun allocatedBuffers(buffers: Array<ByteBuffer>) {
+            frameBytes = buffers[0].run { ByteArray(remaining()).also(::get) }
+            imageInfo = ImageInfo(
+                sourceWidth,
+                sourceHeight,
+                ColorType.BGRA_8888,
+                ColorAlphaType.PREMUL,
+            )
+        }
+    }
+
+    private inner class SkiaBitmapRenderCallback : RenderCallback {
+        override fun display(
+            mediaPlayer: MediaPlayer,
+            nativeBuffers: Array<ByteBuffer>,
+            bufferFormat: BufferFormat,
+        ) {
+            SwingUtilities.invokeLater {
+                nativeBuffers[0].rewind()
+                nativeBuffers[0].get(frameBytes)
+                skiaBitmap.installPixels(imageInfo, frameBytes, bufferFormat.width * 4)
+                composeBitmap.value = skiaBitmap.asComposeImageBitmap()
+            }
+        }
+    }
+
+    private inner class SkiaBitmapVideoSurface : CallbackVideoSurface(
+        SkiaBitmapBufferFormatCallback(),
+        SkiaBitmapRenderCallback(),
+        true,
+        videoSurfaceAdapter,
+    )
+}

--- a/app/shared/video-player/src/desktopMain/kotlin/ui/VideoPlayer.desktop.kt
+++ b/app/shared/video-player/src/desktopMain/kotlin/ui/VideoPlayer.desktop.kt
@@ -94,8 +94,8 @@ class VlcjVideoPlayerState(parentCoroutineContext: CoroutineContext) : PlayerSta
             .mediaPlayers()
             .newEmbeddedMediaPlayer()
     }
-    private val surface = SkiaBitmapVideoSurface().apply {
-        player.videoSurface().set(this)
+    val surface = SkiaBitmapVideoSurface().apply {
+        player.videoSurface().set(this) // 只能 attach 一次
         attach(player)
     }
 
@@ -495,18 +495,11 @@ actual fun VideoPlayer(
     }
 //    DisposableEffect(Unit) { onDispose(mediaPlayer::release) }
 
-    val surface = remember {
-        SkiaBitmapVideoSurface().apply {
-            mediaPlayer.videoSurface().set(this)
-            attach(mediaPlayer)
-        }
-    }
-
     val frameSizeCalculator = remember {
         FrameSizeCalculator()
     }
     Canvas(modifier) {
-        val bitmap = surface.bitmap ?: return@Canvas
+        val bitmap = playerState.surface.bitmap ?: return@Canvas
         frameSizeCalculator.calculate(
             IntSize(bitmap.width, bitmap.height),
             Size(size.width, size.height),


### PR DESCRIPTION
在 PC 播放器使用 native skia 渲染

- 让 VLC 输出到 skia 的 buffer, 然后 compose 直接使用 skia buffer draw Canvas
- 避免播放时的巨额内存分配
- macOS 上的 CPU 占用率由 100% 降低为 40% (无硬件加速情况下)