### PR TITLE
在播放器中自动隐藏鼠标

### DIFF
--- a/app/desktop/src/main/kotlin/AniDesktop.kt
+++ b/app/desktop/src/main/kotlin/AniDesktop.kt
@@ -256,7 +256,12 @@ object AniDesktop {
                 CompositionLocalProvider(
                     LocalContext provides context,
                     LocalWindowState provides windowState,
-                    LocalPlatformWindow provides remember(window.windowHandle) { PlatformWindow(windowHandle = window.windowHandle) },
+                    LocalPlatformWindow provides remember(window.windowHandle) {
+                        PlatformWindow(
+                            windowHandle = window.windowHandle,
+                            composeWindow = window,
+                        )
+                    },
                 ) {
                     // This actually runs only once since app is never changed.
                     val windowImmersed = true

--- a/app/shared/src/androidMain/kotlin/ui/foundation/effects/CursorVisibilityEffect.android.kt
+++ b/app/shared/src/androidMain/kotlin/ui/foundation/effects/CursorVisibilityEffect.android.kt
@@ -1,0 +1,8 @@
+package me.him188.ani.app.ui.foundation.effects
+
+import androidx.compose.runtime.Composable
+
+@Composable
+actual fun CursorVisibilityEffect(key: Any?, visible: Boolean) {
+    // Not supported yet, ignore
+}

--- a/app/shared/src/commonMain/kotlin/ui/foundation/effects/CursorVisibilityEffect.kt
+++ b/app/shared/src/commonMain/kotlin/ui/foundation/effects/CursorVisibilityEffect.kt
@@ -1,0 +1,6 @@
+package me.him188.ani.app.ui.foundation.effects
+
+import androidx.compose.runtime.Composable
+
+@Composable
+expect fun CursorVisibilityEffect(key: Any? = Unit, visible: Boolean = true)

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeVideo.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeVideo.kt
@@ -5,6 +5,9 @@ import androidx.compose.animation.core.snap
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.hoverable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.WindowInsets
@@ -41,6 +44,7 @@ import me.him188.ani.app.platform.isDesktop
 import me.him188.ani.app.platform.isMobile
 import me.him188.ani.app.tools.rememberUiMonoTasker
 import me.him188.ani.app.ui.foundation.LocalIsPreviewing
+import me.him188.ani.app.ui.foundation.effects.CursorVisibilityEffect
 import me.him188.ani.app.ui.foundation.rememberViewModel
 import me.him188.ani.app.ui.subject.episode.statistics.VideoLoadingState
 import me.him188.ani.app.ui.subject.episode.video.loading.EpisodeVideoLoadingIndicator
@@ -113,9 +117,23 @@ internal fun EpisodeVideoImpl(
     var showSettings by remember { mutableStateOf(false) }
     val config by remember(configProvider) { derivedStateOf(configProvider) }
 
+    // auto hide cursor
+    val videoInteractionSource = remember { MutableInteractionSource() }
+    val isVideoHovered by videoInteractionSource.collectIsHoveredAsState()
+    val showCursor by remember(videoControllerState) {
+        derivedStateOf {
+            !isVideoHovered || (videoControllerState.visibility.bottomBar
+                    || videoControllerState.visibility.detachedSlider)
+        }
+    }
+    CursorVisibilityEffect(
+        key = Unit,
+        visible = showCursor,
+    )
+
     VideoScaffold(
         expanded = expanded,
-        modifier = modifier,
+        modifier = modifier.hoverable(videoInteractionSource),
         maintainAspectRatio = maintainAspectRatio,
         controllerState = videoControllerState,
         gestureLocked = { isLocked },

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeViewModel.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeViewModel.kt
@@ -145,6 +145,7 @@ interface EpisodeViewModel : HasBackgroundScope {
 
 
     // Video
+    val videoControllerState: VideoControllerState
     val videoScaffoldConfig: VideoScaffoldConfig
 
     /**
@@ -213,7 +214,7 @@ private class EpisodeViewModelImpl(
         )
     }.shareInBackground(started = SharingStarted.Lazily)
 
-    private val videoControllerState = VideoControllerState(ControllerVisibility.Invisible)
+    override val videoControllerState = VideoControllerState(ControllerVisibility.Invisible)
 
     /**
      * 更换 EP 是否已经完成了.

--- a/app/shared/src/desktopMain/kotlin/platform/window/MacosWindowUtils.kt
+++ b/app/shared/src/desktopMain/kotlin/platform/window/MacosWindowUtils.kt
@@ -1,0 +1,38 @@
+package me.him188.ani.app.platform.window
+
+import androidx.compose.ui.awt.ComposeWindow
+import com.sun.jna.Library
+import com.sun.jna.Native
+import com.sun.jna.Platform
+
+internal class MacosWindowUtils : AwtWindowUtils() {
+    @Suppress("FunctionName")
+    interface Quartz : Library {
+        // Function to hide the cursor
+        fun CGDisplayHideCursor(displayID: Int)
+
+        // Function to show the cursor
+        fun CGDisplayShowCursor(displayID: Int)
+
+        // Function to check if the cursor is visible
+        fun CGCursorIsVisible(): Boolean
+
+        companion object {
+            val INSTANCE: Quartz = Native.load(if (Platform.isMac()) "Quartz" else "c", Quartz::class.java)
+        }
+    }
+
+    override fun isCursorVisible(window: ComposeWindow): Boolean {
+        return Quartz.INSTANCE.CGCursorIsVisible()
+    }
+
+    override fun setCursorVisible(window: ComposeWindow, visible: Boolean) {
+        Quartz.INSTANCE.apply {
+            if (visible) {
+                CGDisplayShowCursor(0)
+            } else {
+                CGDisplayHideCursor(0)
+            }
+        }
+    }
+}

--- a/app/shared/src/desktopMain/kotlin/platform/window/PlatformWindow.desktop.kt
+++ b/app/shared/src/desktopMain/kotlin/platform/window/PlatformWindow.desktop.kt
@@ -1,9 +1,11 @@
 package me.him188.ani.app.platform.window
 
+import androidx.compose.ui.awt.ComposeWindow
 import androidx.compose.ui.geometry.Rect
 
 actual class PlatformWindow(
-    val windowHandle: Long
+    val windowHandle: Long,
+    val composeWindow: ComposeWindow,
 ) {
     var nonFullscreenStyle: Long = 0
     var nonFullscreenExtStyle: Long = 0

--- a/app/shared/src/desktopMain/kotlin/platform/window/WindowUtils.kt
+++ b/app/shared/src/desktopMain/kotlin/platform/window/WindowUtils.kt
@@ -3,7 +3,15 @@ package me.him188.ani.app.platform.window
 import androidx.compose.ui.awt.ComposeWindow
 import androidx.compose.ui.graphics.Color
 import me.him188.ani.app.platform.currentPlatformDesktop
+import java.awt.Cursor
+import java.awt.Point
+import java.awt.Toolkit
+import java.awt.image.BufferedImage
 
+
+/**
+ * @see AwtWindowUtils
+ */
 interface WindowUtils {
     fun setTitleBarColor(hwnd: Long, color: Color): Boolean {
         return false
@@ -15,14 +23,36 @@ interface WindowUtils {
     fun setPreventScreenSaver(prevent: Boolean) {
     }
 
+    fun isCursorVisible(window: ComposeWindow): Boolean
+
+    fun setCursorVisible(window: ComposeWindow, visible: Boolean) {
+    }
+
     companion object : WindowUtils by (when (currentPlatformDesktop) {
-        is me.him188.ani.app.platform.Platform.MacOS -> NoopWindowUtils
+        is me.him188.ani.app.platform.Platform.MacOS -> MacosWindowUtils()
         is me.him188.ani.app.platform.Platform.Windows -> WindowsWindowUtils()
     })
+}
+
+abstract class AwtWindowUtils : WindowUtils {
+    private companion object {
+        private val blankCursor: Cursor by lazy {
+            Toolkit.getDefaultToolkit().createCustomCursor(
+                BufferedImage(16, 16, BufferedImage.TYPE_INT_ARGB), Point(0, 0), "blank cursor",
+            )
+        }
+    }
+
+    override fun isCursorVisible(window: ComposeWindow): Boolean = window.cursor != blankCursor
+
+    override fun setCursorVisible(window: ComposeWindow, visible: Boolean) {
+        val cursor = if (visible) Cursor.getDefaultCursor() else blankCursor
+        window.cursor = cursor
+        window.contentPane.cursor = cursor
+    }
 }
 
 fun ComposeWindow.setTitleBarColor(color: Color) {
     WindowUtils.setTitleBarColor(windowHandle, color)
 }
 
-private object NoopWindowUtils : WindowUtils

--- a/app/shared/src/desktopMain/kotlin/platform/window/WindowsWindowUtils.kt
+++ b/app/shared/src/desktopMain/kotlin/platform/window/WindowsWindowUtils.kt
@@ -17,7 +17,7 @@ import com.sun.jna.ptr.IntByReference
 import com.sun.jna.win32.StdCallLibrary
 import com.sun.jna.win32.W32APIOptions
 
-class WindowsWindowUtils : WindowUtils {
+class WindowsWindowUtils : AwtWindowUtils() {
     private val dwmAPi: Dwmapi = Native.load("dwmapi", Dwmapi::class.java, W32APIOptions.DEFAULT_OPTIONS)
 
     override fun setTitleBarColor(hwnd: Long, color: Color): Boolean {

--- a/app/shared/src/desktopMain/kotlin/ui/foundation/effects/CursorVisibilityEffect.desktop.kt
+++ b/app/shared/src/desktopMain/kotlin/ui/foundation/effects/CursorVisibilityEffect.desktop.kt
@@ -1,0 +1,35 @@
+package me.him188.ani.app.ui.foundation.effects
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import me.him188.ani.app.platform.window.LocalPlatformWindow
+import me.him188.ani.app.platform.window.WindowUtils
+import me.him188.ani.app.ui.foundation.LocalIsPreviewing
+
+const val TAG_CURSOR_VISIBILITY_EFFECT_VISIBLE = "CursorVisibilityEffect-visible"
+const val TAG_CURSOR_VISIBILITY_EFFECT_INVISIBLE = "CursorVisibilityEffect-invisible"
+
+@Composable
+actual fun CursorVisibilityEffect(key: Any?, visible: Boolean) {
+    val isPreviewing = LocalIsPreviewing.current
+    if (isPreviewing) {
+        if (visible) {
+            Box(Modifier.testTag(TAG_CURSOR_VISIBILITY_EFFECT_VISIBLE))
+        } else {
+            Box(Modifier.testTag(TAG_CURSOR_VISIBILITY_EFFECT_INVISIBLE))
+        }
+        return
+    }
+
+    val window = LocalPlatformWindow.current
+    DisposableEffect(key, visible, window) {
+        val original = true
+        WindowUtils.setCursorVisible(window.composeWindow, visible)
+        onDispose {
+            WindowUtils.setCursorVisible(window.composeWindow, original)
+        }
+    }
+}

--- a/app/shared/src/desktopTest/kotlin/ui/subject/episode/EpisodeVideoCursorTest.kt
+++ b/app/shared/src/desktopTest/kotlin/ui/subject/episode/EpisodeVideoCursorTest.kt
@@ -1,0 +1,239 @@
+package me.him188.ani.app.ui.subject.episode
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.requiredWidth
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.test.SemanticsNodeInteractionsProvider
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performMouseInput
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.runSkikoComposeUiTest
+import androidx.compose.ui.test.swipe
+import androidx.compose.ui.unit.dp
+import kotlinx.collections.immutable.persistentListOf
+import me.him188.ani.app.data.models.preference.VideoScaffoldConfig
+import me.him188.ani.app.ui.doesNotExist
+import me.him188.ani.app.ui.exists
+import me.him188.ani.app.ui.foundation.ProvideCompositionLocalsForPreview
+import me.him188.ani.app.ui.foundation.effects.TAG_CURSOR_VISIBILITY_EFFECT_INVISIBLE
+import me.him188.ani.app.ui.foundation.effects.TAG_CURSOR_VISIBILITY_EFFECT_VISIBLE
+import me.him188.ani.app.ui.foundation.stateOf
+import me.him188.ani.app.ui.foundation.theme.aniDarkColorTheme
+import me.him188.ani.app.ui.subject.episode.statistics.VideoLoadingState
+import me.him188.ani.app.videoplayer.ui.ControllerVisibility
+import me.him188.ani.app.videoplayer.ui.VideoControllerState
+import me.him188.ani.app.videoplayer.ui.guesture.GestureFamily
+import me.him188.ani.app.videoplayer.ui.guesture.VIDEO_GESTURE_MOUSE_MOVE_SHOW_CONTROLLER_DURATION
+import me.him188.ani.app.videoplayer.ui.progress.MediaProgressSliderState
+import me.him188.ani.app.videoplayer.ui.progress.PlayerControllerDefaults
+import me.him188.ani.app.videoplayer.ui.progress.TAG_PROGRESS_SLIDER_PREVIEW_POPUP
+import me.him188.ani.app.videoplayer.ui.state.DummyPlayerState
+import me.him188.ani.app.videoplayer.ui.top.PlayerTopBar
+import me.him188.ani.danmaku.ui.DanmakuConfig
+import me.him188.ani.danmaku.ui.DanmakuHostState
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.seconds
+
+class EpisodeVideoCursorTest {
+
+    private val controllerState = VideoControllerState(ControllerVisibility.Invisible)
+    private val playerState = DummyPlayerState()
+    private var currentPositionMillis by mutableLongStateOf(0L)
+    private val progressSliderState: MediaProgressSliderState = MediaProgressSliderState(
+        { currentPositionMillis },
+        { 100_000 },
+        stateOf(persistentListOf()),
+        onPreview = {},
+        onPreviewFinished = { currentPositionMillis = it },
+    )
+
+    private val SemanticsNodeInteractionsProvider.topBar
+        get() = onNodeWithTag(TAG_EPISODE_VIDEO_TOP_BAR, useUnmergedTree = true)
+    private val SemanticsNodeInteractionsProvider.previewPopup
+        get() = onNodeWithTag(TAG_PROGRESS_SLIDER_PREVIEW_POPUP, useUnmergedTree = true)
+
+    private val SemanticsNodeInteractionsProvider.cursorVisible
+        get() = onNodeWithTag(TAG_CURSOR_VISIBILITY_EFFECT_VISIBLE, useUnmergedTree = true)
+
+    private val SemanticsNodeInteractionsProvider.cursorInvisible
+        get() = onNodeWithTag(TAG_CURSOR_VISIBILITY_EFFECT_INVISIBLE, useUnmergedTree = true)
+
+    @Composable
+    private fun Player(gestureFamily: GestureFamily = GestureFamily.MOUSE) {
+        ProvideCompositionLocalsForPreview(colorScheme = aniDarkColorTheme()) {
+            Row {
+                EpisodeVideoImpl(
+                    playerState = playerState,
+                    expanded = true,
+                    hasNextEpisode = true,
+                    onClickNextEpisode = {},
+                    videoControllerState = controllerState,
+                    title = { PlayerTopBar() },
+                    danmakuHostState = remember { DanmakuHostState() },
+                    danmakuEnabled = false,
+                    onToggleDanmaku = {},
+                    videoLoadingState = { VideoLoadingState.Succeed(isBt = true) },
+                    danmakuConfig = { DanmakuConfig.Default },
+                    onClickFullScreen = {},
+                    onExitFullscreen = {},
+                    danmakuEditor = {},
+                    configProvider = { VideoScaffoldConfig.Default },
+                    sideSheets = {},
+                    onShowMediaSelector = {},
+                    onShowSelectEpisode = {},
+                    onClickScreenshot = {},
+                    detachedProgressSlider = {
+                        PlayerControllerDefaults.MediaProgressSlider(
+                            progressSliderState,
+                            cacheProgressState = playerState.cacheProgress,
+                            enabled = false,
+                        )
+                    },
+                    progressSliderState = progressSliderState,
+                    danmakuFrozen = true,
+                    gestureFamily = gestureFamily,
+                    modifier = Modifier.weight(1f),
+                )
+
+                Column(Modifier.fillMaxHeight().requiredWidth(100.dp)) {
+                    Text("Dummy")
+                }
+            }
+        }
+    }
+
+    /**
+     * 初始 controller visible, 会显示指针
+     */
+    @Test
+    fun `initial controller visible`() = runSkikoComposeUiTest {
+        controllerState.toggleFullVisible(true)
+        setContent {
+            Player()
+        }
+        runOnIdle {
+            waitUntil { cursorVisible.exists() }
+        }
+    }
+
+    /**
+     * 初始 controller invisible, 但因为鼠标没有 hover 到视频, 也会显示指针
+     */
+    @Test
+    fun `initial controller invisible`() = runSkikoComposeUiTest {
+        controllerState.toggleFullVisible(false)
+        setContent {
+            Player()
+        }
+        runOnIdle {
+            waitUntil { cursorVisible.exists() } // 因为没有 hover
+        }
+    }
+
+    /**
+     * 初始 controller invisible, 但因为鼠标没有 hover 到视频, 也会显示指针.
+     * 当鼠标滑入视频 (并且 controller 也显示几秒隐藏后), 会显示指针
+     */
+    @Test
+    fun `initial controller invisible and hover`() = runSkikoComposeUiTest {
+        controllerState.toggleFullVisible(false)
+        setContent {
+            Player()
+        }
+        runOnIdle {
+            waitUntil { cursorVisible.exists() } // 因为没有 hover
+        }
+        runOnIdle {
+            onRoot().performMouseInput {
+                moveTo(center)
+            }
+        } // 这里不会因为滑动鼠标而显示 controller 进而显示 cursor, 因为会自动 advance 时间跳过状态
+        runOnIdle {
+            waitUntil { cursorInvisible.exists() }
+        }
+    }
+
+    /**
+     * 滑出视频区域后显示指针
+     */
+    @Test
+    fun `show cursor when outside of video`() = runSkikoComposeUiTest {
+        controllerState.toggleFullVisible(false)
+        setContent {
+            Player()
+        }
+        runOnIdle {
+            waitUntil { cursorVisible.exists() } // 因为没有 hover
+        }
+        runOnIdle {
+            onRoot().performMouseInput {
+                moveTo(center)
+            }
+        }
+        runOnIdle {
+            waitUntil { cursorInvisible.exists() } // hover 了
+        }
+        runOnIdle {
+            onRoot().performMouseInput {
+                moveTo(centerRight) // 移出视频区域
+            }
+        }
+        runOnIdle {
+            assertEquals(ControllerVisibility.Invisible, controllerState.visibility)
+            waitUntil { cursorVisible.exists() }
+        }
+    }
+
+    /**
+     * 在 controller visible 时鼠标滑入播放器, 等待几秒后隐藏 controller, 同时隐藏 cursor
+     */
+    @Test
+    fun `hide cursor after some seconds`() = runSkikoComposeUiTest {
+        controllerState.toggleFullVisible(true)
+        setContent {
+            Player(gestureFamily = GestureFamily.MOUSE)
+        }
+        runOnIdle {
+            assertEquals(true, controllerState.visibility.topBar)
+            waitUntil { cursorVisible.exists() } // 因为没有 hover
+            onRoot().performMouseInput {
+                moveTo(centerRight) // 初始在视频外面
+            }
+        }
+        mainClock.autoAdvance = false
+        runOnIdle {
+            onRoot().performMouseInput {
+                moveTo(center)
+            }
+            // 目前的 controller mouseHoverForController 依赖 Move 事件, 但 compose 似乎有点问题
+            // 所以额外广播一个事件
+            onRoot().performTouchInput {
+                swipe(center, center - Offset(1f, 1f))
+            }
+        }
+        runOnIdle {
+            assertEquals(true, controllerState.visibility.topBar)
+            waitUntil { cursorVisible.exists() }
+        }
+        runOnIdle {
+            mainClock.advanceTimeBy((VIDEO_GESTURE_MOUSE_MOVE_SHOW_CONTROLLER_DURATION + 1.seconds).inWholeMilliseconds)
+            mainClock.autoAdvance = true
+        }
+        runOnIdle {
+            waitUntil { topBar.doesNotExist() }
+            waitUntil { cursorInvisible.doesNotExist() }
+            assertEquals(false, controllerState.visibility.topBar)
+        }
+    }
+}

--- a/app/shared/src/iosMain/kotlin/ui/foundation/effects/CursorVisibilityEffect.ios.kt
+++ b/app/shared/src/iosMain/kotlin/ui/foundation/effects/CursorVisibilityEffect.ios.kt
@@ -1,0 +1,8 @@
+package me.him188.ani.app.ui.foundation.effects
+
+import androidx.compose.runtime.Composable
+
+@Composable
+actual fun CursorVisibilityEffect(key: Any?, visible: Boolean) {
+    // Not supported yet, ignore
+}


### PR DESCRIPTION
当鼠标悬浮在播放器区域内并且控制器没有显示时, 隐藏鼠标. 

macOS 用的是 native API (JNA), Windows 用的 AWT.

增加了 UI test cases, 但是只真机测试了 macos.

close #531
