### PR TITLE
fix: ikaros episode seq type to float.

### DIFF
--- a/data-sources/ikaros/src/IkarosClient.kt
+++ b/data-sources/ikaros/src/IkarosClient.kt
@@ -80,7 +80,7 @@ class IkarosClient(
         return baseUrl + url
     }
 
-    suspend fun subjectDetails2SizedSource(subjectDetails: IkarosSubjectDetails, seq: Int): SizedSource<MediaMatch> {
+    suspend fun subjectDetails2SizedSource(subjectDetails: IkarosSubjectDetails, seq: Float): SizedSource<MediaMatch> {
         val episodes = subjectDetails.episodes
         val mediaMatchs = mutableListOf<MediaMatch>()
         val episode = episodes.find { ep -> ep.sequence == seq && "MAIN" == ep.group }

--- a/data-sources/ikaros/src/IkarosMediaSource.kt
+++ b/data-sources/ikaros/src/IkarosMediaSource.kt
@@ -68,7 +68,7 @@ class IkarosMediaSource(config: MediaSourceConfig) : HttpMediaSource() {
 
     override suspend fun fetch(query: MediaFetchRequest): SizedSource<MediaMatch> {
         val subjectId = checkNotNull(query.subjectId)
-        val episodeSort = checkNotNull(query.episodeSort.number?.toInt())
+        val episodeSort = checkNotNull(query.episodeSort.number)
         val ikarosSubjectDetails = checkNotNull(client.postSubjectSyncBgmTv(subjectId))
         return client.subjectDetails2SizedSource(ikarosSubjectDetails, episodeSort)
     }

--- a/data-sources/ikaros/src/models/IkarosEpisodeDetails.kt
+++ b/data-sources/ikaros/src/models/IkarosEpisodeDetails.kt
@@ -11,7 +11,7 @@ data class IkarosEpisodeDetails(
     @SerialName("name_cn") val nameCn: String?,
     val description: String?,
     @SerialName("air_time") val airTime: String?,
-    val sequence: Int,
+    val sequence: Float,
     val resources: List<IkarosEpisodeResource?>? = null,
     val group: String,
 )


### PR DESCRIPTION
ikaros在[v0.15.2](https://github.com/ikaros-dev/ikaros/milestone/48?closed=1)之后，剧集序号更新为浮点型，
Ani这边需要将ikaros数据源的剧集序号的类型也更新为浮点型

- https://github.com/ikaros-dev/ikaros/pull/645