### PR TITLE
正确支持使用模板创建带有配置的数据源

### DIFF
--- a/app/shared/src/androidMain/kotlin/ui/settings/tabs/network/EditMediaSourceDialog.android.kt
+++ b/app/shared/src/androidMain/kotlin/ui/settings/tabs/network/EditMediaSourceDialog.android.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import kotlinx.coroutines.flow.flowOf
 import me.him188.ani.app.ui.foundation.ProvideCompositionLocalsForPreview
+import me.him188.ani.datasources.api.source.FactoryId
 import me.him188.ani.datasources.api.source.MediaSourceConfig
 import me.him188.ani.datasources.api.source.MediaSourceInfo
 import me.him188.ani.datasources.api.source.parameter.MediaSourceParameters
@@ -16,7 +17,8 @@ private fun PreviewEditMediaSourceDialogNoConfig() {
     ProvideCompositionLocalsForPreview {
         EditMediaSourceDialog(
             state = EditMediaSourceState(
-                mediaSourceId = "test",
+                editingMediaSourceId = "test",
+                factoryId = FactoryId("test"),
                 info = MediaSourceInfo(
                     displayName = "Test",
                     description = "Test description",
@@ -38,7 +40,8 @@ private fun PreviewEditMediaSourceDialog() {
     ProvideCompositionLocalsForPreview {
         EditMediaSourceDialog(
             state = EditMediaSourceState(
-                mediaSourceId = "test",
+                editingMediaSourceId = "test",
+                factoryId = FactoryId("test"),
                 info = MediaSourceInfo(
                     displayName = "Test",
                     description = "Test description",

--- a/app/shared/src/androidMain/kotlin/ui/subject/episode/details/components/PlayingEpisodeItem.android.kt
+++ b/app/shared/src/androidMain/kotlin/ui/subject/episode/details/components/PlayingEpisodeItem.android.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import me.him188.ani.app.data.source.media.TestMediaList
+import me.him188.ani.app.data.source.media.TestMediaSourceInfo
 import me.him188.ani.app.ui.foundation.ProvideCompositionLocalsForPreview
 import me.him188.ani.app.ui.subject.episode.details.renderProperties
 import me.him188.ani.app.ui.subject.episode.statistics.VideoLoadingState
@@ -69,7 +70,9 @@ private fun PreviewEpisodeItemImpl(
             mediaSource = {
                 var isLoading by remember { mutableStateOf(false) }
                 PlayingEpisodeItemDefaults.MediaSource(
-                    media = null, isLoading = isLoading,
+                    media = null,
+                    mediaSourceInfo = TestMediaSourceInfo,
+                    isLoading = isLoading,
                     onClick = { isLoading = !isLoading },
                     modifier = Modifier.clickable {
                         isLoading = !isLoading

--- a/app/shared/src/androidMain/kotlin/ui/subject/episode/mediaFetch/MediaSelector.android.kt
+++ b/app/shared/src/androidMain/kotlin/ui/subject/episode/mediaFetch/MediaSelector.android.kt
@@ -29,7 +29,7 @@ internal val previewMediaList = TestMediaList.run {
 @PreviewLightDark
 @Composable
 private fun PreviewMediaSelector() {
-    val mediaSelector = rememberMediaSelectorPresentation {
+    val mediaSelector = rememberMediaSelectorPresentation(rememberTestMediaSourceInfoProvider()) {
         DefaultMediaSelector(
             mediaSelectorContextNotCached = flowOf(MediaSelectorContext.EmptyForPreview),
             mediaListNotCached = MutableStateFlow(
@@ -62,3 +62,4 @@ private fun PreviewMediaSelector() {
         )
     }
 }
+

--- a/app/shared/src/androidMain/kotlin/ui/subject/episode/statistics/PlayerStatistics.android.kt
+++ b/app/shared/src/androidMain/kotlin/ui/subject/episode/statistics/PlayerStatistics.android.kt
@@ -1,9 +1,7 @@
 package me.him188.ani.app.ui.subject.episode.statistics
 
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
 import me.him188.ani.app.data.source.danmaku.AniDanmakuProvider
+import me.him188.ani.app.ui.foundation.stateOf
 import me.him188.ani.danmaku.api.DanmakuMatchInfo
 import me.him188.ani.danmaku.api.DanmakuMatchMethod
 import me.him188.ani.danmaku.dandanplay.DandanplayDanmakuProvider
@@ -40,21 +38,14 @@ private fun halfFuzzy() = DanmakuMatchInfo(
     method = DanmakuMatchMethod.ExactSubjectFuzzyEpisode("Subject Title", "Episode Title"),
 )
 
-
-class TestVideoStatistics : VideoStatistics() {
-    override var mediaSourceLoading: Boolean by mutableStateOf(false)
-    override var playingMedia: Media? by mutableStateOf(null)
-    override var playingFilename: String? by mutableStateOf(null)
-    override var videoLoadingState: VideoLoadingState by mutableStateOf(VideoLoadingState.Initial)
-}
-
 fun testPlayerStatisticsState(
     playingMedia: Media? = null,
     playingFilename: String = "filename-filename-filename-filename-filename-filename-filename.mkv",
     videoLoadingState: VideoLoadingState = VideoLoadingState.Initial,
-) =
-    TestVideoStatistics().apply {
-        this.playingMedia = playingMedia
-        this.playingFilename = playingFilename
-        this.videoLoadingState = videoLoadingState
-    }
+) = VideoStatistics(
+    playingMedia = stateOf(playingMedia),
+    playingMediaSourceInfo = stateOf(null),
+    playingFilename = stateOf(playingFilename),
+    mediaSourceLoading = stateOf(true),
+    videoLoadingState = stateOf(videoLoadingState),
+)

--- a/app/shared/src/androidMain/kotlin/ui/subject/episode/video/sidesheet/EpisodeVideoMediaSelectorSideSheet.android.kt
+++ b/app/shared/src/androidMain/kotlin/ui/subject/episode/video/sidesheet/EpisodeVideoMediaSelectorSideSheet.android.kt
@@ -9,6 +9,7 @@ import me.him188.ani.app.ui.foundation.ProvideCompositionLocalsForPreview
 import me.him188.ani.app.ui.foundation.preview.PHONE_LANDSCAPE
 import me.him188.ani.app.ui.subject.episode.mediaFetch.emptyMediaSourceResultsPresentation
 import me.him188.ani.app.ui.subject.episode.mediaFetch.rememberTestMediaSelectorPresentation
+import me.him188.ani.app.ui.subject.episode.mediaFetch.rememberTestMediaSourceInfoProvider
 import me.him188.ani.utils.platform.annotations.TestOnly
 
 @Composable
@@ -20,6 +21,7 @@ fun PreviewEpisodeVideoMediaSelectorSideSheet() {
         EpisodeVideoMediaSelectorSideSheet(
             mediaSelectorPresentation = rememberTestMediaSelectorPresentation(),
             mediaSourceResultsPresentation = emptyMediaSourceResultsPresentation(),
+            rememberTestMediaSourceInfoProvider(),
             onDismissRequest = {},
         )
     }

--- a/app/shared/src/commonMain/kotlin/data/repository/MediaSourceInstanceRepository.kt
+++ b/app/shared/src/commonMain/kotlin/data/repository/MediaSourceInstanceRepository.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.serialization.Serializable
 import me.him188.ani.app.data.source.media.instance.MediaSourceSave
+import me.him188.ani.datasources.api.source.FactoryId
 import me.him188.ani.datasources.api.source.MediaSourceConfig
 import me.him188.ani.datasources.mikan.MikanCNMediaSource
 import me.him188.ani.utils.platform.Uuid
@@ -33,9 +34,14 @@ data class MediaSourceSaves(
     companion object {
         val Empty = MediaSourceSaves(emptyList())
         val Default: MediaSourceSaves by lazy {
-            fun createSave(it: String, isEnabled: Boolean) = MediaSourceSave(
+            fun createSave(
+                sourceId: String,
+                factoryId: FactoryId,
+                isEnabled: Boolean
+            ) = MediaSourceSave(
                 instanceId = Uuid.randomString(),
-                mediaSourceId = it,
+                mediaSourceId = sourceId,
+                factoryId = factoryId,
                 isEnabled = isEnabled,
                 config = MediaSourceConfig.Default,
             )
@@ -48,9 +54,9 @@ data class MediaSourceSaves(
 
             MediaSourceSaves(
                 buildList {
-                    enabledWebSources.forEach { add(createSave(it, isEnabled = true)) }
-                    enabledBtSources.forEach { add(createSave(it, isEnabled = true)) }
-                    disabledBtSources.forEach { add(createSave(it, isEnabled = false)) }
+                    enabledWebSources.forEach { add(createSave(it, FactoryId(it), isEnabled = true)) }
+                    enabledBtSources.forEach { add(createSave(it, FactoryId(it), isEnabled = true)) }
+                    disabledBtSources.forEach { add(createSave(it, FactoryId(it), isEnabled = false)) }
                 },
             )
         }

--- a/app/shared/src/commonMain/kotlin/data/source/media/MediaTestData.kt
+++ b/app/shared/src/commonMain/kotlin/data/source/media/MediaTestData.kt
@@ -6,6 +6,7 @@ import me.him188.ani.datasources.api.MediaExtraFiles
 import me.him188.ani.datasources.api.MediaProperties
 import me.him188.ani.datasources.api.Subtitle
 import me.him188.ani.datasources.api.SubtitleKind
+import me.him188.ani.datasources.api.source.MediaSourceInfo
 import me.him188.ani.datasources.api.source.MediaSourceKind
 import me.him188.ani.datasources.api.source.MediaSourceLocation
 import me.him188.ani.datasources.api.topic.EpisodeRange
@@ -22,11 +23,40 @@ const val SOURCE_DMHY = "dmhy"
 @TestOnly
 const val SOURCE_ACG = "acg.rip"
 
+@TestOnly
+fun createTestDefaultMedia(
+    mediaId: String,
+    mediaSourceId: String, // e.g. "dmhy"
+    originalUrl: String,
+    download: ResourceLocation,
+    originalTitle: String,
+    publishedTime: Long,
+    properties: MediaProperties,
+    episodeRange: EpisodeRange?,
+    extraFiles: MediaExtraFiles = MediaExtraFiles.Empty,
+    location: MediaSourceLocation,
+    kind: MediaSourceKind,
+//    mediaSourceInstanceId: String = mediaSourceId,
+): DefaultMedia = DefaultMedia(
+    mediaId = mediaId,
+    mediaSourceId = mediaSourceId,
+//    mediaSourceInstanceId = mediaSourceInstanceId,
+    originalUrl = originalUrl,
+    download = download,
+    originalTitle = originalTitle,
+    publishedTime = publishedTime,
+    properties = properties,
+    episodeRange = episodeRange,
+    extraFiles = extraFiles,
+    location = location,
+    kind = kind,
+)
+
 // Used by many test, don't change it. 
 // If you want to change it, copy it instead.
 @TestOnly
 val TestMediaList = listOf(
-    DefaultMedia(
+    createTestDefaultMedia(
         mediaId = "$SOURCE_DMHY.1",
         mediaSourceId = SOURCE_DMHY,
         originalTitle = "[桜都字幕组] 孤独摇滚 ABC ABC ABC ABC ABC ABC ABC ABC ABC ABC",
@@ -54,7 +84,7 @@ val TestMediaList = listOf(
         ),
     ),
     // exactly same properties as the first one, except for the ids.
-    DefaultMedia(
+    createTestDefaultMedia(
         mediaId = "$SOURCE_ACG.1",
         mediaSourceId = SOURCE_ACG,
         originalTitle = "[桜都字幕组] 孤独摇滚 ABC ABC ABC ABC ABC ABC ABC ABC ABC ABC",
@@ -73,7 +103,7 @@ val TestMediaList = listOf(
         location = MediaSourceLocation.Online,
     ),
 
-    DefaultMedia(
+    createTestDefaultMedia(
         mediaId = "$SOURCE_DMHY.2",
         mediaSourceId = SOURCE_DMHY,
         originalTitle = "夜晚的水母不会游泳",
@@ -91,7 +121,7 @@ val TestMediaList = listOf(
         kind = MediaSourceKind.BitTorrent,
         location = MediaSourceLocation.Online,
     ),
-    DefaultMedia(
+    createTestDefaultMedia(
         mediaId = "$SOURCE_ACG.2",
         mediaSourceId = SOURCE_ACG,
         originalTitle = "葬送的芙莉莲",
@@ -109,7 +139,7 @@ val TestMediaList = listOf(
         kind = MediaSourceKind.BitTorrent,
         location = MediaSourceLocation.Online,
     ),
-    DefaultMedia(
+    createTestDefaultMedia(
         mediaId = "$SOURCE_ACG.3",
         mediaSourceId = SOURCE_ACG,
         originalTitle = "某个生肉",
@@ -128,3 +158,6 @@ val TestMediaList = listOf(
         location = MediaSourceLocation.Online,
     ),
 )
+
+@TestOnly
+val TestMediaSourceInfo = MediaSourceInfo("Mikan")

--- a/app/shared/src/commonMain/kotlin/data/source/media/cache/MediaCacheManager.kt
+++ b/app/shared/src/commonMain/kotlin/data/source/media/cache/MediaCacheManager.kt
@@ -112,6 +112,9 @@ abstract class MediaCacheManager(
     }
 
     companion object {
+        /**
+         * 本地数据源不允许有多个示例. 必须是 Factory:MediaSource:Instance = 1:1:1 的关系.
+         */
         const val LOCAL_FS_MEDIA_SOURCE_ID = "local-file-system"
     }
 }

--- a/app/shared/src/commonMain/kotlin/data/source/media/fetch/MediaFetcher.kt
+++ b/app/shared/src/commonMain/kotlin/data/source/media/fetch/MediaFetcher.kt
@@ -290,10 +290,10 @@ class MediaSourceMediaFetcher(
 
         override val mediaSourceResults: List<MediaSourceFetchResult> = mediaSources.map { instance ->
             MediaSourceResultImpl(
-                mediaSourceId = instance.mediaSourceId,
-                instance.source.info,
-                instance.source.kind,
-                config,
+                mediaSourceId = instance.source.mediaSourceId,
+                sourceInfo = instance.source.info,
+                kind = instance.source.kind,
+                config = config,
                 disabled = !instance.isEnabled,
                 pagedSources = this.request
                     .onEach {

--- a/app/shared/src/commonMain/kotlin/data/source/media/fetch/MediaSourceManager.kt
+++ b/app/shared/src/commonMain/kotlin/data/source/media/fetch/MediaSourceManager.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.shareIn
@@ -22,6 +23,7 @@ import me.him188.ani.app.data.source.media.instance.MediaSourceInstance
 import me.him188.ani.app.data.source.media.instance.MediaSourceSave
 import me.him188.ani.app.platform.ServiceLoader
 import me.him188.ani.app.platform.getAniUserAgent
+import me.him188.ani.datasources.api.source.FactoryId
 import me.him188.ani.datasources.api.source.MediaFetchRequest
 import me.him188.ani.datasources.api.source.MediaSource
 import me.him188.ani.datasources.api.source.MediaSourceConfig
@@ -52,12 +54,12 @@ interface MediaSourceManager { // available by inject
     /**
      * 全部的 [MediaSource], 包括那些设置里关闭的, 包括本地的.
      */
-    val allFactoryIds: List<String>
+    val allFactoryIds: List<FactoryId>
 
     /**
      * 全部的 [MediaSource], 包括那些设置里关闭的, 但不包括本地的.
      */
-    val allFactoryIdsExceptLocal: List<String>
+    val allFactoryIdsExceptLocal: List<FactoryId>
         get() = allFactoryIds.filter { !isLocal(it) }
 
     /**
@@ -65,25 +67,39 @@ interface MediaSourceManager { // available by inject
      */
     val mediaFetcher: Flow<MediaFetcher>
 
+    fun isLocal(factoryId: FactoryId): Boolean = isLocal(factoryId.value)
     fun isLocal(mediaSourceId: String): Boolean {
         return mediaSourceId == LOCAL_FS_MEDIA_SOURCE_ID
     }
 
     fun instanceConfigFlow(instanceId: String): Flow<MediaSourceConfig>
 
-    fun findInfoByMediaSourceId(mediaSourceId: String): MediaSourceInfo? {
-        if (mediaSourceId == "Bangumi") { // workaround for bangumi connectivity testing
-            return MediaSourceInfo(
-                "Bangumi",
-                "提供观看记录数据",
-                "https://bangumi.tv",
-                "https://bangumi.tv/img/favicon.ico",
-            )
-        }
-        return allFactories.find { it.mediaSourceId == mediaSourceId }?.info
+    fun findInfoByFactoryId(factoryId: FactoryId): MediaSourceInfo? {
+        return allFactories.find { it.factoryId == factoryId }?.info
     }
 
-    suspend fun addInstance(mediaSourceId: String, config: MediaSourceConfig)
+    fun infoFlowByMediaSourceId(mediaSourceId: String): Flow<MediaSourceInfo?> {
+        if (mediaSourceId == "Bangumi") { // workaround for bangumi connectivity testing
+            return flowOf(
+                MediaSourceInfo(
+                    "Bangumi",
+                    "提供观看记录数据",
+                    "https://bangumi.tv",
+                    "https://bangumi.tv/img/favicon.ico",
+                ),
+            )
+        }
+        return allInstances.map { list ->
+            list.find { it.mediaSourceId == mediaSourceId }?.source?.info
+        }
+    }
+
+    suspend fun addInstance(
+        mediaSourceId: String,
+        factoryId: FactoryId,
+        config: MediaSourceConfig
+    )
+
     suspend fun updateConfig(instanceId: String, config: MediaSourceConfig)
     suspend fun setEnabled(instanceId: String, enabled: Boolean)
     suspend fun removeInstance(instanceId: String)
@@ -101,6 +117,11 @@ fun MediaSourceManager.createFetchFetchSessionFlow(requestLazy: Flow<MediaFetchR
     this.mediaFetcher.map { it.newSession(requestLazy) }
 
 class MediaSourceManagerImpl(
+    /**
+     * 必须是 Factory:MediaSource:Instance = 1:1:1 的关系.
+     *
+     * @see LOCAL_FS_MEDIA_SOURCE_ID
+     */
     additionalSources: () -> List<MediaSource>, // local sources, calculated only once
     flowCoroutineContext: CoroutineContext = Dispatchers.Default,
 ) : MediaSourceManager, KoinComponent {
@@ -124,11 +145,11 @@ class MediaSourceManagerImpl(
     private val additionalSources by lazy {
         additionalSources().map { source ->
             MediaSourceInstance(
-                source.mediaSourceId,
-                source.mediaSourceId,
-                true,
-                MediaSourceConfig.Default,
-                source,
+                instanceId = source.mediaSourceId,
+                factoryId = FactoryId(source.mediaSourceId),
+                isEnabled = true,
+                config = MediaSourceConfig.Default,
+                source = source,
             )
         }
     }
@@ -142,25 +163,25 @@ class MediaSourceManagerImpl(
     override val allFactories: List<MediaSourceFactory> get() = factories
 
     private fun createInstance(save: MediaSourceSave, config: MediaSourceProxySettings): MediaSourceInstance? {
-        val factory = factories.find { it.mediaSourceId == save.mediaSourceId }
+        val factory = factories.find { it.factoryId == save.factoryId }
         return if (factory == null) {
             logger.error { "MediaSourceFactory not found for ${save.mediaSourceId}" }
             null
         } else {
             MediaSourceInstance(
-                save.instanceId,
-                save.mediaSourceId,
-                save.isEnabled,
-                save.config,
-                factory.create(config, save.config),
+                instanceId = save.instanceId,
+                factoryId = save.factoryId,
+                isEnabled = save.isEnabled,
+                config = save.config,
+                source = factory.create(config, save.mediaSourceId, save.config),
             )
         }
     }
 
-    override val allFactoryIds: List<String> by lazy {
+    override val allFactoryIds: List<FactoryId> by lazy {
         factories
-            .map { it.mediaSourceId }
-            .plus(this.additionalSources.map { it.mediaSourceId })
+            .map { it.factoryId }
+            .plus(this.additionalSources.map { it.factoryId })
     }
 
     override val mediaFetcher: Flow<MediaFetcher> = allInstances.map { instances ->
@@ -176,10 +197,11 @@ class MediaSourceManagerImpl(
         }
     }
 
-    override suspend fun addInstance(mediaSourceId: String, config: MediaSourceConfig) {
+    override suspend fun addInstance(mediaSourceId: String, factoryId: FactoryId, config: MediaSourceConfig) {
         val save = MediaSourceSave(
             instanceId = Uuid.randomString(),
             mediaSourceId = mediaSourceId,
+            factoryId = factoryId,
             isEnabled = true,
             config = config,
         )
@@ -202,6 +224,7 @@ class MediaSourceManagerImpl(
 
     private fun MediaSourceFactory.create(
         globalProxySettings: MediaSourceProxySettings,
+        mediaSourceId: String,
         config: MediaSourceConfig,
     ): MediaSource {
         val mediaSourceConfig = config.copy(
@@ -211,7 +234,7 @@ class MediaSourceManagerImpl(
         return when (this) {
             is MikanMediaSource.Factory -> create(mediaSourceConfig, mikanIndexCacheRepository)
             is MikanCNMediaSource.Factory -> create(mediaSourceConfig, mikanIndexCacheRepository)
-            else -> create(mediaSourceConfig)
+            else -> create(mediaSourceId, mediaSourceConfig)
         }
     }
 

--- a/app/shared/src/commonMain/kotlin/data/source/media/instance/MediaSourceInstance.kt
+++ b/app/shared/src/commonMain/kotlin/data/source/media/instance/MediaSourceInstance.kt
@@ -2,9 +2,13 @@ package me.him188.ani.app.data.source.media.instance
 
 import androidx.compose.runtime.Stable
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
+import me.him188.ani.datasources.api.source.FactoryId
 import me.him188.ani.datasources.api.source.MediaSource
 import me.him188.ani.datasources.api.source.MediaSourceConfig
 import me.him188.ani.utils.platform.Uuid
+import me.him188.ani.utils.platform.annotations.SerializationOnly
+import me.him188.ani.utils.platform.annotations.TestOnly
 
 /**
  * [MediaSource], 以及它的配置, 统称为 [MediaSourceInstance].
@@ -12,7 +16,7 @@ import me.him188.ani.utils.platform.Uuid
 @Stable
 class MediaSourceInstance(
     val instanceId: String, // uuid, to be persisted
-    val mediaSourceId: String,
+    val factoryId: FactoryId,
     val isEnabled: Boolean,
     val config: MediaSourceConfig,
     val source: MediaSource,
@@ -20,27 +24,45 @@ class MediaSourceInstance(
     override fun close() {
         source.close()
     }
+
+    val mediaSourceId: String get() = source.mediaSourceId
 }
 
+/**
+ * 用于持久化 [MediaSourceInstance]
+ */
 // 持久化在文件里
 @Serializable
-data class MediaSourceSave(
+data class MediaSourceSave @SerializationOnly constructor(
     val instanceId: String,
     val mediaSourceId: String,
+    val factoryId: FactoryId = FactoryId(mediaSourceId),
     val isEnabled: Boolean,
     val config: MediaSourceConfig,
-)
+    @Transient private val _primaryConstructorMarker: Int = 0,
+) {
+    @OptIn(SerializationOnly::class)
+    constructor(
+        instanceId: String,
+        mediaSourceId: String,
+        factoryId: FactoryId,
+        isEnabled: Boolean,
+        config: MediaSourceConfig,
+    ) : this(instanceId, mediaSourceId, factoryId, isEnabled, config, 0)
+}
 
+@TestOnly
 fun createTestMediaSourceInstance(
     source: MediaSource,
     instanceId: String = Uuid.randomString(),
     mediaSourceId: String = source.mediaSourceId,
     isEnabled: Boolean = true,
     config: MediaSourceConfig = MediaSourceConfig.Default,
+    factoryId: FactoryId = FactoryId(mediaSourceId),
 ): MediaSourceInstance {
     return MediaSourceInstance(
         instanceId = instanceId,
-        mediaSourceId = mediaSourceId,
+        factoryId = factoryId,
         isEnabled = isEnabled,
         config = config,
         source = source,

--- a/app/shared/src/commonMain/kotlin/ui/cache/details/CacheGroupDetailsPage.kt
+++ b/app/shared/src/commonMain/kotlin/ui/cache/details/CacheGroupDetailsPage.kt
@@ -20,13 +20,13 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import me.him188.ani.app.data.source.media.cache.MediaCacheManager
 import me.him188.ani.app.data.source.media.fetch.MediaSourceManager
@@ -59,9 +59,9 @@ class MediaCacheDetailsPageViewModel(
     private val originMediaFlow = mediaCacheFlow.map { it?.origin }
 
     val media by originMediaFlow.produceState(null)
-    val sourceInfo: MediaSourceInfo? by derivedStateOf {
-        media?.mediaSourceId?.let { mediaSourceManager.findInfoByMediaSourceId(it) }
-    }
+    val sourceInfo: MediaSourceInfo? by originMediaFlow.flatMapLatest { media ->
+        media?.mediaSourceId?.let { mediaSourceManager.infoFlowByMediaSourceId(it) } ?: flowOf(null)
+    }.produceState(null)
 }
 
 @Composable

--- a/app/shared/src/commonMain/kotlin/ui/settings/framework/AbstractSettingsViewModel.kt
+++ b/app/shared/src/commonMain/kotlin/ui/settings/framework/AbstractSettingsViewModel.kt
@@ -116,13 +116,14 @@ abstract class AbstractSettingsViewModel : AbstractViewModel(), KoinComponent {
     class SingleTester<T>(
         tester: Tester<T>,
         backgroundScope: CoroutineScope,
-    ) : Testers<T>(listOf(tester), backgroundScope) {
+    ) : Testers<Tester<T>>(listOf(tester), backgroundScope) {
         val tester get() = testers.single()
     }
 
+    // 堆屎咯
     @Stable
-    open class Testers<T>(
-        val testers: List<Tester<T>>,
+    open class Testers<TT : Tester<*>>(
+        val testers: List<TT>,
         backgroundScope: CoroutineScope,
     ) {
         private val testScope = MonoTasker(backgroundScope)

--- a/app/shared/src/commonMain/kotlin/ui/settings/framework/ConnectionTester.kt
+++ b/app/shared/src/commonMain/kotlin/ui/settings/framework/ConnectionTester.kt
@@ -3,7 +3,6 @@ package me.him188.ani.app.ui.settings.framework
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Cancel
@@ -20,19 +19,12 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import me.him188.ani.app.data.source.media.fetch.MediaSourceManager
-import me.him188.ani.app.ui.settings.framework.components.SettingsScope
-import me.him188.ani.app.ui.settings.framework.components.TextItem
-import me.him188.ani.app.ui.settings.rendering.MediaSourceIcon
-import me.him188.ani.datasources.api.source.MediaSourceInfo
-import org.koin.mp.KoinPlatform
 import kotlin.time.Duration
 import kotlin.time.DurationUnit
 import kotlin.time.measureTimedValue
@@ -102,34 +94,6 @@ open class Tester<T>(
             }
         }
     }
-}
-
-@Composable
-fun SettingsScope.MediaSourceTesterView(
-    tester: ConnectionTester,
-    info: MediaSourceInfo? = kotlin.run { // shit
-        KoinPlatform.getKoin().get<MediaSourceManager>()
-            .findInfoByMediaSourceId(tester.id)
-    },
-    showTime: Boolean,
-    title: @Composable RowScope.() -> Unit = { Text(info?.displayName ?: "未知") },
-    description: (@Composable () -> Unit)? = info?.description?.let {
-        { Text(it) }
-    },
-    icon: (@Composable () -> Unit)? = {
-        Box(Modifier.clip(MaterialTheme.shapes.extraSmall).size(48.dp)) {
-            MediaSourceIcon(info?.imageUrl, Modifier.matchParentSize())
-        }
-    },
-) {
-    TextItem(
-        description = description,
-        icon = icon,
-        action = {
-            ConnectionTesterResultIndicator(tester, showTime = showTime)
-        },
-        title = title,
-    )
 }
 
 @Composable

--- a/app/shared/src/commonMain/kotlin/ui/settings/tabs/network/NetworkSettingsTab.kt
+++ b/app/shared/src/commonMain/kotlin/ui/settings/tabs/network/NetworkSettingsTab.kt
@@ -1,5 +1,8 @@
 package me.him188.ani.app.ui.settings.tabs.network
 
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Public
 import androidx.compose.material3.Icon
@@ -9,20 +12,28 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import me.him188.ani.app.Res
+import me.him188.ani.app.bangumi
 import me.him188.ani.app.data.models.preference.ProxySettings
 import me.him188.ani.app.data.source.danmaku.AniBangumiSeverBaseUrls
 import me.him188.ani.app.ui.external.placeholder.placeholder
 import me.him188.ani.app.ui.foundation.rememberViewModel
 import me.him188.ani.app.ui.settings.SettingsTab
-import me.him188.ani.app.ui.settings.framework.MediaSourceTesterView
+import me.him188.ani.app.ui.settings.framework.ConnectionTesterResultIndicator
 import me.him188.ani.app.ui.settings.framework.components.SettingsScope
 import me.him188.ani.app.ui.settings.framework.components.SwitchItem
 import me.him188.ani.app.ui.settings.framework.components.TextButtonItem
 import me.him188.ani.app.ui.settings.framework.components.TextFieldItem
+import me.him188.ani.app.ui.settings.framework.components.TextItem
 import me.him188.ani.utils.ktor.ClientProxyConfigValidator
+import org.jetbrains.compose.resources.painterResource
 
 @Composable
 fun NetworkSettingsTab(
@@ -45,7 +56,24 @@ private fun SettingsScope.OtherTestGroup(vm: NetworkSettingsViewModel) {
         title = { Text("其他测试") },
     ) {
         for (tester in vm.otherTesters.testers) {
-            MediaSourceTesterView(tester, showTime = false)
+            TextItem(
+                description = { Text("提供观看记录数据") },
+                icon = {
+                    Box(Modifier.clip(MaterialTheme.shapes.extraSmall).size(48.dp)) {
+                        Image(
+                            painterResource(Res.drawable.bangumi), null,
+                            contentScale = ContentScale.Crop,
+                            alignment = Alignment.Center,
+                        )
+                    }
+                },
+                action = {
+                    ConnectionTesterResultIndicator(tester, showTime = false)
+                },
+                title = {
+                    Text("Bangumi")
+                },
+            )
         }
 
         TextButtonItem(
@@ -197,8 +225,20 @@ private fun SettingsScope.DanmakuGroup(vm: NetworkSettingsViewModel) {
                     val currentlySelected by derivedStateOf {
                         vm.danmakuSettings.value.useGlobal == (tester.id == AniBangumiSeverBaseUrls.GLOBAL)
                     }
-                    MediaSourceTesterView(
-                        tester,
+                    TextItem(
+                        description = when {
+                            currentlySelected -> {
+                                { Text("当前使用") }
+                            }
+
+                            tester.id == AniBangumiSeverBaseUrls.GLOBAL -> {
+                                { Text("建议在其他地区使用") }
+                            }
+
+                            else -> {
+                                { Text("建议在中国大陆和香港使用") }
+                            }
+                        },
                         icon = {
                             if (tester.id == AniBangumiSeverBaseUrls.GLOBAL)
                                 Icon(
@@ -207,6 +247,12 @@ private fun SettingsScope.DanmakuGroup(vm: NetworkSettingsViewModel) {
                                 )
                             else Text("CN", fontFamily = FontFamily.Monospace)
 
+                        },
+                        action = {
+                            ConnectionTesterResultIndicator(
+                                tester,
+                                showTime = true,
+                            )
                         },
                         title = {
                             val textColor =
@@ -221,20 +267,6 @@ private fun SettingsScope.DanmakuGroup(vm: NetworkSettingsViewModel) {
                                 Text("中国大陆", color = textColor)
                             }
                         },
-                        description = when {
-                            currentlySelected -> {
-                                { Text("当前使用") }
-                            }
-
-                            tester.id == AniBangumiSeverBaseUrls.GLOBAL -> {
-                                { Text("建议在其他地区使用") }
-                            }
-
-                            else -> {
-                                { Text("建议在中国大陆和香港使用") }
-                            }
-                        },
-                        showTime = true,
                     )
                 }
 

--- a/app/shared/src/commonMain/kotlin/ui/subject/cache/CacheListGroup.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/cache/CacheListGroup.kt
@@ -60,6 +60,7 @@ import me.him188.ani.app.ui.foundation.widgets.ProgressIndicatorHeight
 import me.him188.ani.app.ui.settings.framework.components.SettingsScope
 import me.him188.ani.app.ui.settings.framework.components.TextItem
 import me.him188.ani.app.ui.subject.episode.mediaFetch.MediaSelectorView
+import me.him188.ani.app.ui.subject.episode.mediaFetch.MediaSourceInfoProvider
 import me.him188.ani.app.ui.subject.episode.mediaFetch.MediaSourceResultsView
 import me.him188.ani.app.ui.subject.episode.mediaFetch.rememberMediaSelectorPresentation
 import me.him188.ani.app.ui.subject.episode.mediaFetch.rememberMediaSourceResultsPresentation
@@ -103,6 +104,7 @@ data class EpisodeCacheInfo(
 @Composable
 fun SettingsScope.EpisodeCacheListGroup(
     state: EpisodeCacheListState,
+    mediaSourceInfoProvider: MediaSourceInfoProvider,
     mediaSelectorSettingsProvider: () -> Flow<MediaSelectorSettings>,
     modifier: Modifier = Modifier,
 ) {
@@ -142,17 +144,18 @@ fun SettingsScope.EpisodeCacheListGroup(
                 sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
                 modifier = Modifier,
             ) {
-                val selectorPresentation = rememberMediaSelectorPresentation { task.mediaSelector }
+                val selectorPresentation =
+                    rememberMediaSelectorPresentation(mediaSourceInfoProvider) { task.mediaSelector }
                 MediaSelectorView(
                     selectorPresentation,
                     sourceResults = { MediaSourceResultsView(sourceResults, selectorPresentation) },
-                    onClickItem = {
-                        state.selectMedia(it)
-                    },
                     modifier = Modifier.padding(vertical = 12.dp, horizontal = 16.dp)
                         .navigationBarsPadding()
                         .fillMaxHeight() // 防止添加筛选后数量变少导致 bottom sheet 高度变化
                         .fillMaxWidth(),
+                    onClickItem = {
+                        state.selectMedia(it)
+                    },
                     bottomActions = {
                         TextButton({ state.cancelRequest() }) {
                             Text("取消")

--- a/app/shared/src/commonMain/kotlin/ui/subject/cache/SubjectCacheScene.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/cache/SubjectCacheScene.kt
@@ -56,6 +56,7 @@ import me.him188.ani.app.ui.foundation.stateOf
 import me.him188.ani.app.ui.foundation.widgets.TopAppBarGoBackButton
 import me.him188.ani.app.ui.settings.SettingsTab
 import me.him188.ani.app.ui.settings.framework.components.SettingsScope
+import me.him188.ani.app.ui.subject.episode.mediaFetch.MediaSourceInfoProvider
 import me.him188.ani.utils.coroutines.flows.combine
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
@@ -71,6 +72,8 @@ interface SubjectCacheViewModel {
      * 单个条目的缓存管理页面的状态
      */
     val cacheListState: EpisodeCacheListState
+
+    val mediaSourceInfoProvider: MediaSourceInfoProvider
 }
 
 @Stable
@@ -165,6 +168,11 @@ class SubjectCacheViewModelImpl(
             }
         },
     )
+    override val mediaSourceInfoProvider: MediaSourceInfoProvider = MediaSourceInfoProvider(
+        getSourceInfoFlow = {
+            mediaSourceManager.infoFlowByMediaSourceId(it)
+        },
+    )
 
     init {
         launchInBackground {
@@ -235,6 +243,7 @@ fun SubjectCacheScene(
         cacheListGroup = {
             EpisodeCacheListGroup(
                 vm.cacheListState,
+                vm.mediaSourceInfoProvider,
                 mediaSelectorSettingsProvider = {
                     vm.mediaSelectorSettingsFlow
                 },

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodePage.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodePage.kt
@@ -640,6 +640,7 @@ private fun EpisodeVideo(
         mediaSourceResultsPresentation = vm.mediaSourceResultsPresentation,
         episodeSelectorState = vm.episodeSelectorState,
         progressSliderState = progressSliderState,
+        mediaSourceInfoProvider = vm.mediaSourceInfoProvider,
         leftBottomTips = {
             AnimatedVisibility(
                 visible = vm.playerSkipOpEdState.showSkipTips,

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeVideo.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeVideo.kt
@@ -51,6 +51,7 @@ import me.him188.ani.app.ui.foundation.effects.cursorVisibility
 import me.him188.ani.app.ui.foundation.rememberDebugSettingsViewModel
 import me.him188.ani.app.ui.foundation.rememberViewModel
 import me.him188.ani.app.ui.subject.episode.mediaFetch.MediaSelectorPresentation
+import me.him188.ani.app.ui.subject.episode.mediaFetch.MediaSourceInfoProvider
 import me.him188.ani.app.ui.subject.episode.mediaFetch.MediaSourceResultsPresentation
 import me.him188.ani.app.ui.subject.episode.statistics.VideoLoadingState
 import me.him188.ani.app.ui.subject.episode.video.loading.EpisodeVideoLoadingIndicator
@@ -126,6 +127,7 @@ internal fun EpisodeVideoImpl(
     mediaSelectorPresentation: MediaSelectorPresentation,
     mediaSourceResultsPresentation: MediaSourceResultsPresentation,
     episodeSelectorState: EpisodeSelectorState,
+    mediaSourceInfoProvider: MediaSourceInfoProvider,
     leftBottomTips: @Composable () -> Unit,
     modifier: Modifier = Modifier,
     maintainAspectRatio: Boolean = !expanded,
@@ -427,6 +429,7 @@ internal fun EpisodeVideoImpl(
                 EpisodeVideoMediaSelectorSideSheet(
                     mediaSelectorPresentation,
                     mediaSourceResultsPresentation,
+                    mediaSourceInfoProvider,
                     onDismissRequest = { isMediaSelectorVisible = false },
                 )
             }

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeViewModel.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeViewModel.kt
@@ -75,6 +75,7 @@ import me.him188.ani.app.ui.subject.components.comment.EditCommentSticker
 import me.him188.ani.app.ui.subject.episode.details.EpisodeCarouselState
 import me.him188.ani.app.ui.subject.episode.details.EpisodeDetailsState
 import me.him188.ani.app.ui.subject.episode.mediaFetch.MediaSelectorPresentation
+import me.him188.ani.app.ui.subject.episode.mediaFetch.MediaSourceInfoProvider
 import me.him188.ani.app.ui.subject.episode.mediaFetch.MediaSourceResultsPresentation
 import me.him188.ani.app.ui.subject.episode.statistics.VideoStatistics
 import me.him188.ani.app.ui.subject.episode.video.DanmakuLoaderImpl
@@ -160,6 +161,8 @@ interface EpisodeViewModel : HasBackgroundScope {
      * 是否显示数据源选择器
      */
     var mediaSelectorVisible: Boolean
+
+    val mediaSourceInfoProvider: MediaSourceInfoProvider
 
 
     // Video
@@ -312,8 +315,12 @@ private class EpisodeViewModelImpl(
             }
         }
 
+    override val mediaSourceInfoProvider: MediaSourceInfoProvider = MediaSourceInfoProvider(
+        getSourceInfoFlow = { mediaSourceManager.infoFlowByMediaSourceId(it) },
+    )
+
     override val mediaSelectorPresentation: MediaSelectorPresentation =
-        MediaSelectorPresentation(mediaSelector, backgroundScope.coroutineContext)
+        MediaSelectorPresentation(mediaSelector, mediaSourceInfoProvider, backgroundScope.coroutineContext)
 
     override val mediaSourceResultsPresentation: MediaSourceResultsPresentation =
         MediaSourceResultsPresentation(
@@ -328,7 +335,7 @@ private class EpisodeViewModelImpl(
         playerStateFactory.create(context, backgroundScope.coroutineContext)
 
     private val playerLauncher: PlayerLauncher = PlayerLauncher(
-        mediaSelector, videoSourceResolver, playerState,
+        mediaSelector, videoSourceResolver, playerState, mediaSourceInfoProvider,
         episodeInfo,
         mediaFetchSession.flatMapLatest { it.hasCompleted }.map { !it },
         backgroundScope.coroutineContext,

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/details/EpisodeDetails.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/details/EpisodeDetails.kt
@@ -236,6 +236,7 @@ fun EpisodeDetails(
                             var showMediaSelector by rememberSaveable { mutableStateOf(false) }
                             PlayingEpisodeItemDefaults.MediaSource(
                                 media = originalMedia,
+                                mediaSourceInfo = videoStatistics.playingMediaSourceInfo,
                                 isLoading = videoStatistics.mediaSourceLoading,
                                 onClick = { showMediaSelector = !showMediaSelector },
                             )

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/details/EpisodePlayMediaSelector.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/details/EpisodePlayMediaSelector.kt
@@ -33,15 +33,15 @@ fun EpisodePlayMediaSelector(
         modifier.padding(vertical = 12.dp, horizontal = 16.dp)
             .fillMaxWidth()
             .navigationBarsPadding(),
+        itemProgressBar = {},
+        onClickItem = {
+            mediaSelector.select(it)
+            onSelected(it)
+        },
         bottomActions = {
             TextButton(onDismissRequest) {
                 Text("取消")
             }
         },
-        onClickItem = {
-            mediaSelector.select(it)
-            onSelected(it)
-        },
-        itemProgressBar = {},
     )
 }

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/details/components/PlayingEpisodeItem.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/details/components/PlayingEpisodeItem.kt
@@ -36,7 +36,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -44,14 +43,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import me.him188.ani.app.data.source.media.fetch.MediaSourceManager
 import me.him188.ani.app.ui.foundation.icons.PlayingIcon
 import me.him188.ani.app.ui.foundation.layout.paddingIfNotEmpty
 import me.him188.ani.app.ui.foundation.text.ProvideContentColor
 import me.him188.ani.app.ui.foundation.text.ProvideTextStyleContentColor
 import me.him188.ani.app.ui.settings.rendering.MediaSourceIcons
 import me.him188.ani.datasources.api.Media
-import org.koin.mp.KoinPlatform
+import me.him188.ani.datasources.api.source.MediaSourceInfo
 
 /**
  * 剧集详情页中的正在播放的剧集卡片. 需要放在合适的 `Card` 中.
@@ -227,6 +225,7 @@ object PlayingEpisodeItemDefaults {
     @Composable
     fun MediaSource(
         media: Media?,
+        mediaSourceInfo: MediaSourceInfo?,
         isLoading: Boolean,
         onClick: () -> Unit,
         modifier: Modifier = Modifier,
@@ -241,11 +240,7 @@ object PlayingEpisodeItemDefaults {
                     Icon(MediaSourceIcons.location(media.location, media.kind), null)
 
                     Text(
-                        remember(media.mediaSourceId) {
-                            KoinPlatform.getKoin().get<MediaSourceManager>()
-                                .findInfoByMediaSourceId(media.mediaSourceId)
-                                ?.displayName ?: "未知"
-                        },
+                        mediaSourceInfo?.displayName ?: "未知",
                         Modifier.padding(start = 12.dp).align(Alignment.CenterVertically),
                         maxLines = 1,
                         softWrap = false,

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/mediaFetch/MediaSelectorView.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/mediaFetch/MediaSelectorView.kt
@@ -32,14 +32,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import me.him188.ani.app.data.source.media.fetch.MediaSourceManager
 import me.him188.ani.app.tools.formatDateTime
 import me.him188.ani.app.ui.foundation.widgets.FastLinearProgressIndicator
 import me.him188.ani.app.ui.settings.rendering.MediaSourceIcons
 import me.him188.ani.app.ui.subject.episode.details.renderSubtitleLanguage
 import me.him188.ani.datasources.api.Media
 import me.him188.ani.datasources.api.topic.FileSize
-import org.koin.mp.KoinPlatform
 
 
 private inline val WINDOW_VERTICAL_PADDING get() = 8.dp
@@ -118,6 +116,7 @@ fun MediaSelectorView(
                 Column {
                     MediaItem(
                         item,
+                        state.mediaSourceInfoProvider,
                         state.selected == item,
                         state,
                         onClick = { onClickItem(item) },
@@ -154,6 +153,7 @@ fun MediaSelectorView(
 @Composable
 private fun MediaItem(
     media: Media,
+    mediaSourceInfoProvider: MediaSourceInfoProvider,
     selected: Boolean,
     state: MediaSelectorPresentation,
     onClick: () -> Unit,
@@ -227,11 +227,8 @@ private fun MediaItem(
                             Icon(MediaSourceIcons.location(media.location, media.kind), null)
 
                             Text(
-                                remember(media.mediaSourceId) {
-                                    KoinPlatform.getKoin().get<MediaSourceManager>()
-                                        .findInfoByMediaSourceId(media.mediaSourceId)
-                                        ?.displayName ?: "未知"
-                                },
+                                mediaSourceInfoProvider.rememberMediaSourceInfo(media.mediaSourceId).value?.displayName
+                                    ?: "未知",
                                 maxLines = 1,
                                 softWrap = false,
                             )

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/mediaFetch/MediaSourceInfoProvider.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/mediaFetch/MediaSourceInfoProvider.kt
@@ -1,0 +1,45 @@
+package me.him188.ani.app.ui.subject.episode.mediaFetch
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.remember
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import me.him188.ani.datasources.api.source.MediaSourceInfo
+import me.him188.ani.utils.platform.annotations.TestOnly
+import moe.tlaster.precompose.flow.collectAsStateWithLifecycle
+
+/**
+ * 用于支持获取 mediaSourceId 的 [MediaSourceInfo]
+ */
+@Stable
+class MediaSourceInfoProvider(
+    val getSourceInfoFlow: (mediaSourceId: String) -> Flow<MediaSourceInfo?>,
+) {
+    @Composable
+    fun rememberMediaSourceInfo(mediaSourceId: String): State<MediaSourceInfo?> {
+        return remember {
+            getSourceInfoFlow(mediaSourceId)
+        }.collectAsStateWithLifecycle(null)
+    }
+}
+
+
+@Composable
+@TestOnly
+fun rememberTestMediaSourceInfoProvider(): MediaSourceInfoProvider {
+    return remember {
+        createTestMediaSourceInfoProvider()
+    }
+}
+
+
+@TestOnly
+fun createTestMediaSourceInfoProvider(): MediaSourceInfoProvider {
+    return MediaSourceInfoProvider(
+        getSourceInfoFlow = {
+            flowOf(MediaSourceInfo(displayName = it))
+        },
+    )
+}

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/statistics/VideoStatistics.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/statistics/VideoStatistics.kt
@@ -40,40 +40,40 @@ import me.him188.ani.app.data.source.media.selector.MediaSelector
 import me.him188.ani.app.ui.foundation.text.ProvideContentColor
 import me.him188.ani.app.ui.subject.episode.details.renderProperties
 import me.him188.ani.datasources.api.Media
+import me.him188.ani.datasources.api.source.MediaSourceInfo
 
 /**
  * 视频统计信息, 用于获取当前播放器正在播放的视频的来源 [Media] 和文件名, 以及弹幕信息.
  */
 @Stable
-abstract class VideoStatistics {
+class VideoStatistics(
+    playingMedia: State<Media?>,
+    playingMediaSourceInfo: State<MediaSourceInfo?>,
+    playingFilename: State<String?>,
+    mediaSourceLoading: State<Boolean>,
+    videoLoadingState: State<VideoLoadingState>,
+) {
     /**
      * [MediaFetcher] 的所有数据源是否都已经加载完成.
      */
-    abstract val mediaSourceLoading: Boolean
+    val mediaSourceLoading by mediaSourceLoading
 
     /**
      * 从 [MediaSelector] 选择后就有
      */
-    abstract val playingMedia: Media?
+    val playingMedia by playingMedia
+
+    /**
+     * [playingMedia] 所属的 [MediaSourceInfo]
+     */
+    val playingMediaSourceInfo: MediaSourceInfo? by playingMediaSourceInfo
+
 
     /**
      * 要播放器获取到视频文件后才有
      */
-    abstract val playingFilename: String?
-    abstract val videoLoadingState: VideoLoadingState
-}
-
-@Stable
-class DelegateVideoStatistics(
-    playingMedia: State<Media?>,
-    playingFilename: State<String?>,
-    mediaSourceLoading: State<Boolean>,
-    videoLoadingState: State<VideoLoadingState>,
-) : VideoStatistics() {
-    override val mediaSourceLoading by mediaSourceLoading
-    override val playingMedia by playingMedia
-    override val playingFilename by playingFilename
-    override val videoLoadingState by videoLoadingState
+    val playingFilename by playingFilename
+    val videoLoadingState by videoLoadingState
 }
 
 @Composable

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/video/sidesheet/EpisodeVideoMediaSelectorSideSheet.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/video/sidesheet/EpisodeVideoMediaSelectorSideSheet.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.unit.dp
 import me.him188.ani.app.ui.subject.episode.TAG_MEDIA_SELECTOR_SHEET
 import me.him188.ani.app.ui.subject.episode.mediaFetch.MediaSelectorPresentation
 import me.him188.ani.app.ui.subject.episode.mediaFetch.MediaSelectorView
+import me.him188.ani.app.ui.subject.episode.mediaFetch.MediaSourceInfoProvider
 import me.him188.ani.app.ui.subject.episode.mediaFetch.MediaSourceResultsPresentation
 import me.him188.ani.app.ui.subject.episode.mediaFetch.MediaSourceResultsView
 import me.him188.ani.app.ui.subject.episode.video.settings.EpisodeVideoSettingsSideSheet
@@ -23,6 +24,7 @@ import me.him188.ani.app.ui.subject.episode.video.settings.EpisodeVideoSettingsS
 fun EpisodeVideoMediaSelectorSideSheet(
     mediaSelectorPresentation: MediaSelectorPresentation,
     mediaSourceResultsPresentation: MediaSourceResultsPresentation,
+    mediaSourceInfoProvider: MediaSourceInfoProvider,
     onDismissRequest: () -> Unit,
     modifier: Modifier = Modifier,
 ) {

--- a/app/shared/src/desktopTest/kotlin/data/source/media/cache/DirectoryMediaCacheStorageTest.kt
+++ b/app/shared/src/desktopTest/kotlin/data/source/media/cache/DirectoryMediaCacheStorageTest.kt
@@ -14,12 +14,12 @@ import kotlinx.serialization.json.put
 import me.him188.ani.app.data.models.preference.ProxySettings
 import me.him188.ani.app.data.source.media.cache.engine.TorrentMediaCacheEngine
 import me.him188.ani.app.data.source.media.cache.storage.DirectoryMediaCacheStorage
+import me.him188.ani.app.data.source.media.createTestDefaultMedia
 import me.him188.ani.app.tools.torrent.TorrentEngine
 import me.him188.ani.app.tools.torrent.engines.AnitorrentConfig
 import me.him188.ani.app.tools.torrent.engines.AnitorrentEngine
 import me.him188.ani.app.torrent.anitorrent.session.AnitorrentDownloadSession
 import me.him188.ani.app.torrent.anitorrent.test.TestAnitorrentTorrentDownloader
-import me.him188.ani.datasources.api.DefaultMedia
 import me.him188.ani.datasources.api.EpisodeSort
 import me.him188.ani.datasources.api.MediaCacheMetadata
 import me.him188.ani.datasources.api.MediaProperties
@@ -88,7 +88,7 @@ class DirectoryMediaCacheStorageTest {
         )
     }
 
-    private val media = DefaultMedia(
+    private val media = createTestDefaultMedia(
         mediaId = "dmhy.2",
         mediaSourceId = "dmhy",
         originalTitle = "夜晚的水母不会游泳 02 测试剧集",

--- a/app/shared/src/desktopTest/kotlin/data/source/media/cache/requester/EpisodeCacheRequesterTest.kt
+++ b/app/shared/src/desktopTest/kotlin/data/source/media/cache/requester/EpisodeCacheRequesterTest.kt
@@ -12,6 +12,7 @@ import me.him188.ani.app.data.source.media.SOURCE_DMHY
 import me.him188.ani.app.data.source.media.TestMediaList
 import me.him188.ani.app.data.source.media.cache.TestMediaCache
 import me.him188.ani.app.data.source.media.cache.storage.TestMediaCacheStorage
+import me.him188.ani.app.data.source.media.createTestDefaultMedia
 import me.him188.ani.app.data.source.media.fetch.MediaFetcherConfig
 import me.him188.ani.app.data.source.media.fetch.MediaSourceMediaFetcher
 import me.him188.ani.app.data.source.media.fetch.awaitCompletion
@@ -273,7 +274,7 @@ class EpisodeCacheRequesterTest {
 
     @Test
     fun `SelectMedia tryAutoSelectByCachedSeason selects none for inputs matching single ep`() = runTest {
-        val originalMedia = DefaultMedia(
+        val originalMedia = createTestDefaultMedia(
             mediaId = "$SOURCE_DMHY.1",
             mediaSourceId = SOURCE_DMHY,
             originalTitle = "[桜都字幕组] 孤独摇滚 ABC ABC ABC ABC ABC ABC ABC ABC ABC ABC",
@@ -322,7 +323,7 @@ class EpisodeCacheRequesterTest {
 
     @Test
     fun `SelectMedia tryAutoSelectByCachedSeason selects none for inputs without matching ep`() = runTest {
-        val originalMedia = DefaultMedia(
+        val originalMedia = createTestDefaultMedia(
             mediaId = "$SOURCE_DMHY.1",
             mediaSourceId = SOURCE_DMHY,
             originalTitle = "[桜都字幕组] 孤独摇滚 ABC ABC ABC ABC ABC ABC ABC ABC ABC ABC",
@@ -371,7 +372,7 @@ class EpisodeCacheRequesterTest {
 
     @Suppress("SameParameterValue")
     private fun createDefaultMedia(id: String, epRange: EpisodeRange): DefaultMedia {
-        return DefaultMedia(
+        return createTestDefaultMedia(
             mediaId = id,
             mediaSourceId = SOURCE_DMHY,
             originalTitle = "[桜都字幕组] 孤独摇滚 ABC ABC ABC ABC ABC ABC ABC ABC ABC ABC",

--- a/app/shared/src/desktopTest/kotlin/data/source/media/selector/AbstractDefaultMediaSelectorTest.kt
+++ b/app/shared/src/desktopTest/kotlin/data/source/media/selector/AbstractDefaultMediaSelectorTest.kt
@@ -2,6 +2,7 @@ package me.him188.ani.app.data.source.media.selector
 
 import kotlinx.coroutines.flow.MutableStateFlow
 import me.him188.ani.app.data.models.preference.MediaSelectorSettings
+import me.him188.ani.app.data.source.media.createTestDefaultMedia
 import me.him188.ani.app.ui.subject.episode.mediaFetch.MediaPreference
 import me.him188.ani.datasources.api.DefaultMedia
 import me.him188.ani.datasources.api.EpisodeSort
@@ -111,7 +112,7 @@ sealed class AbstractDefaultMediaSelectorTest {
         extraFiles: MediaExtraFiles = MediaExtraFiles.Empty,
     ): DefaultMedia {
         val id = mediaId++
-        return DefaultMedia(
+        return createTestDefaultMedia(
             mediaId = "$sourceId.$id",
             mediaSourceId = sourceId,
             originalTitle = "[字幕组] 孤独摇滚 $id",

--- a/app/shared/src/desktopTest/kotlin/data/source/media/selector/MediaSelectorAutoSelectTest.kt
+++ b/app/shared/src/desktopTest/kotlin/data/source/media/selector/MediaSelectorAutoSelectTest.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.test.runTest
 import me.him188.ani.app.data.models.preference.MediaSelectorSettings
 import me.him188.ani.app.data.source.media.SOURCE_DMHY
 import me.him188.ani.app.data.source.media.TestMediaList
+import me.him188.ani.app.data.source.media.createTestDefaultMedia
 import me.him188.ani.app.data.source.media.fetch.MediaFetcherConfig
 import me.him188.ani.app.data.source.media.fetch.MediaSourceMediaFetcher
 import me.him188.ani.app.data.source.media.instance.createTestMediaSourceInstance
@@ -153,7 +154,7 @@ class MediaSelectorAutoSelectTest {
 
     @Test
     fun `selectCached selects one when there is one cache`() = runTest {
-        val target = DefaultMedia(
+        val target = createTestDefaultMedia(
             mediaId = "$SOURCE_DMHY.1",
             mediaSourceId = SOURCE_DMHY,
             originalTitle = "[桜都字幕组] 孤独摇滚 ABC ABC ABC ABC ABC ABC ABC ABC ABC ABC",
@@ -179,7 +180,7 @@ class MediaSelectorAutoSelectTest {
 
     @Test
     fun `selectCached selects first one when there are multiple caches`() = runTest {
-        val target = DefaultMedia(
+        val target = createTestDefaultMedia(
             mediaId = "$SOURCE_DMHY.1",
             mediaSourceId = SOURCE_DMHY,
             originalTitle = "[桜都字幕组] 孤独摇滚 ABC ABC ABC ABC ABC ABC ABC ABC ABC ABC",

--- a/app/shared/src/desktopTest/kotlin/ui/subject/episode/EpisodeVideoControllerTest.kt
+++ b/app/shared/src/desktopTest/kotlin/ui/subject/episode/EpisodeVideoControllerTest.kt
@@ -29,6 +29,7 @@ import me.him188.ani.app.ui.foundation.theme.aniDarkColorTheme
 import me.him188.ani.app.ui.framework.AniComposeUiTest
 import me.him188.ani.app.ui.framework.runAniComposeUiTest
 import me.him188.ani.app.ui.subject.episode.mediaFetch.rememberTestMediaSelectorPresentation
+import me.him188.ani.app.ui.subject.episode.mediaFetch.rememberTestMediaSourceInfoProvider
 import me.him188.ani.app.ui.subject.episode.mediaFetch.rememberTestMediaSourceResults
 import me.him188.ani.app.ui.subject.episode.statistics.VideoLoadingState
 import me.him188.ani.app.ui.subject.episode.video.sidesheet.rememberTestEpisodeSelectorState
@@ -136,6 +137,7 @@ class EpisodeVideoControllerTest {
                 mediaSelectorPresentation = rememberTestMediaSelectorPresentation(),
                 mediaSourceResultsPresentation = rememberTestMediaSourceResults(),
                 episodeSelectorState = rememberTestEpisodeSelectorState(),
+                mediaSourceInfoProvider = rememberTestMediaSourceInfoProvider(),
                 gestureFamily = gestureFamily,
             )
         }

--- a/app/shared/src/desktopTest/kotlin/ui/subject/episode/EpisodeVideoCursorTest.kt
+++ b/app/shared/src/desktopTest/kotlin/ui/subject/episode/EpisodeVideoCursorTest.kt
@@ -32,6 +32,7 @@ import me.him188.ani.app.ui.foundation.stateOf
 import me.him188.ani.app.ui.foundation.theme.aniDarkColorTheme
 import me.him188.ani.app.ui.framework.runAniComposeUiTest
 import me.him188.ani.app.ui.subject.episode.mediaFetch.rememberTestMediaSelectorPresentation
+import me.him188.ani.app.ui.subject.episode.mediaFetch.rememberTestMediaSourceInfoProvider
 import me.him188.ani.app.ui.subject.episode.mediaFetch.rememberTestMediaSourceResults
 import me.him188.ani.app.ui.subject.episode.statistics.VideoLoadingState
 import me.him188.ani.app.ui.subject.episode.video.sidesheet.rememberTestEpisodeSelectorState
@@ -109,6 +110,7 @@ class EpisodeVideoCursorTest {
                     mediaSelectorPresentation = rememberTestMediaSelectorPresentation(),
                     mediaSourceResultsPresentation = rememberTestMediaSourceResults(),
                     episodeSelectorState = rememberTestEpisodeSelectorState(),
+                    mediaSourceInfoProvider = rememberTestMediaSourceInfoProvider(),
                     modifier = Modifier.weight(1f),
                 )
 

--- a/app/shared/video-player/src/androidMain/kotlin/ui/VideoScaffold.android.kt
+++ b/app/shared/video-player/src/androidMain/kotlin/ui/VideoScaffold.android.kt
@@ -16,6 +16,7 @@ import me.him188.ani.app.ui.foundation.ProvideCompositionLocalsForPreview
 import me.him188.ani.app.ui.foundation.preview.PHONE_LANDSCAPE
 import me.him188.ani.app.ui.subject.episode.EpisodeVideoImpl
 import me.him188.ani.app.ui.subject.episode.mediaFetch.rememberTestMediaSelectorPresentation
+import me.him188.ani.app.ui.subject.episode.mediaFetch.rememberTestMediaSourceInfoProvider
 import me.him188.ani.app.ui.subject.episode.mediaFetch.rememberTestMediaSourceResults
 import me.him188.ani.app.ui.subject.episode.statistics.VideoLoadingState
 import me.him188.ani.app.ui.subject.episode.video.sidesheet.rememberTestEpisodeSelectorState
@@ -122,6 +123,7 @@ private fun PreviewVideoScaffoldImpl(
         mediaSelectorPresentation = rememberTestMediaSelectorPresentation(),
         mediaSourceResultsPresentation = rememberTestMediaSourceResults(),
         episodeSelectorState = rememberTestEpisodeSelectorState(),
+        mediaSourceInfoProvider = rememberTestMediaSourceInfoProvider(),
         leftBottomTips = {
             PlayerControllerDefaults.LeftBottomTips(onClick = {})
         },

--- a/data-sources/api/src/commonMain/kotlin/source/MediaSourceFactory.kt
+++ b/data-sources/api/src/commonMain/kotlin/source/MediaSourceFactory.kt
@@ -7,35 +7,54 @@ import me.him188.ani.datasources.api.source.parameter.MediaSourceParameters
 import me.him188.ani.utils.ktor.ClientProxyConfig
 import me.him188.ani.utils.ktor.proxy
 import me.him188.ani.utils.ktor.userAgent
+import kotlin.jvm.JvmInline
+
+@JvmInline
+@Serializable
+value class FactoryId(
+    // 强制类型检查, 防止跟 mediaSourceId 弄混 (历史遗留问题, 有太多的 mediaSourceId 了)
+    val value: String,
+) {
+    override fun toString(): String = value
+}
 
 /**
+ * 表示一个数据源类型, 可以构造多个该类型的实例. 例如 RSS 类型可以构造出适配不同站点的实例.
+ *
  * 负责定义 [MediaSource] 的可配置参数列表, 并使用这些参数创建一个示例.
  *
  * @see MediaSource
  */
 interface MediaSourceFactory { // SPI service load
     /**
-     * @see MediaSource.mediaSourceId
+     * 不一定和 [MediaSource.mediaSourceId] 相同, 因为一个数据源类型可能有多个实例.
      */
-    val mediaSourceId: String
+    val factoryId: FactoryId
 
     /**
      * 是否允许用户使用此模板创建多个实例. 不同的实例可以用不同的配置.
+     *
+     * 如果设置为 `true`, 构造的 [MediaSource] 就必须采用 [create] 时传入的 `mediaSourceId` 参数.
      */
     val allowMultipleInstances: Boolean get() = false
 
     /**
      * 数据源的可配置参数列表. 例如 API key, 用户名密码等.
-     * @see MediaSourceParametersBuilder
      */
     val parameters: MediaSourceParameters get() = MediaSourceParameters.Empty
 
+    /**
+     * 初始的配置信息, 仅在创建数据源时有用. 之后将使用 [MediaSource.info]
+     */
     val info: MediaSourceInfo
 
     /**
      * 必须返回新实例.
+     *
+     * @param mediaSourceId 系统为数据源分配的唯一 ID. 注意, 历史遗留的, 不支持多个实例的旧数据源实现会忽略这个参数.
      */
     fun create(
+        mediaSourceId: String,
         config: MediaSourceConfig,
     ): MediaSource
 }
@@ -55,7 +74,7 @@ data class MediaSourceConfig(
 }
 
 operator fun <T> MediaSourceConfig.get(parameter: MediaSourceParameter<T>): T =
-    arguments[parameter.name]?.let { parameter.parseFromString(it) } ?: parameter.default
+    arguments[parameter.name]?.let { parameter.parseFromString(it) } ?: parameter.default()
 
 fun HttpClientConfig<*>.applyMediaSourceConfig(
     config: MediaSourceConfig,

--- a/data-sources/api/src/commonMain/kotlin/source/TopicMediaSource.kt
+++ b/data-sources/api/src/commonMain/kotlin/source/TopicMediaSource.kt
@@ -40,7 +40,7 @@ abstract class TopicMediaSource : HttpMediaSource() {
 
 // Only used by data source modules
 data class DownloadSearchQuery(
-    val keywords: String? = null,
+    val keywords: String,
     val category: TopicCategory? = null,
     val alliance: Alliance? = null,
     val ordering: SearchOrdering? = null,

--- a/data-sources/api/src/commonMain/kotlin/source/parameter/MediaSourceParameter.kt
+++ b/data-sources/api/src/commonMain/kotlin/source/parameter/MediaSourceParameter.kt
@@ -3,7 +3,7 @@ package me.him188.ani.datasources.api.source.parameter
 sealed interface MediaSourceParameter<T> {
     val name: String
     val description: String?  // todo: how to localize?
-    val default: T
+    val default: () -> T
 
     fun parseFromString(value: String): T
 }
@@ -14,7 +14,8 @@ private val NoopSanitizer: (String) -> String = { it }
 class StringParameter(
     override val name: String,
     override val description: String? = null,
-    override val default: String = "",
+    override val default: () -> String,
+    val placeholder: String? = null,
     val isRequired: Boolean = false,
     /**
      * 验证用户输入是否合法
@@ -45,7 +46,7 @@ class StringParameter(
 data class BooleanParameter(
     override val name: String,
     override val description: String? = null,
-    override val default: Boolean,
+    override val default: () -> Boolean,
 ) : MediaSourceParameter<Boolean> {
     init {
         require(name.isNotEmpty()) { "name must not be empty" }
@@ -60,12 +61,11 @@ data class SimpleEnumParameter(
     override val name: String,
     val oneOf: List<String>,
     override val description: String? = null,
-    override val default: String,
+    override val default: () -> String,
 ) : MediaSourceParameter<String> {
     init {
         require(name.isNotEmpty()) { "name must not be empty" }
         require(oneOf.isNotEmpty()) { "oneOf must not be empty" }
-        require(default in oneOf) { "default value must be in oneOf" }
     }
 
     override fun parseFromString(value: String): String {

--- a/data-sources/api/src/commonMain/kotlin/source/parameter/MediaSourceParameters.kt
+++ b/data-sources/api/src/commonMain/kotlin/source/parameter/MediaSourceParameters.kt
@@ -25,13 +25,15 @@ open class MediaSourceParametersBuilder {
      */
     fun string(
         name: String,
-        default: String? = null,
+        defaultProvider: (() -> String)? = null,
         description: String? = null,
+        placeholder: String? = null,
     ): StringParameter {
         val param = StringParameter(
             name, description,
-            default = default ?: "",
-            isRequired = default == null,
+            default = defaultProvider ?: { "" },
+            isRequired = defaultProvider == null,
+            placeholder = placeholder,
         )
         add(param)
         return param
@@ -45,7 +47,7 @@ open class MediaSourceParametersBuilder {
         default: Boolean,
         description: String? = null,
     ): BooleanParameter {
-        val param = BooleanParameter(name, description, default)
+        val param = BooleanParameter(name, description) { default }
         add(param)
         return param
     }
@@ -59,7 +61,7 @@ open class MediaSourceParametersBuilder {
         default: String,
         description: String? = null,
     ): SimpleEnumParameter {
-        val param = SimpleEnumParameter(name, oneOf, description, default)
+        val param = SimpleEnumParameter(name, oneOf, description) { default }
         add(param)
         return param
     }
@@ -81,4 +83,3 @@ open class MediaSourceParametersBuilder {
 
     fun build(): MediaSourceParameters = MediaSourceParameters(list)
 }
-

--- a/data-sources/bt/acg.rip/src/AcgRipMediaSource.kt
+++ b/data-sources/bt/acg.rip/src/AcgRipMediaSource.kt
@@ -28,6 +28,7 @@ import me.him188.ani.datasources.api.paging.Paged
 import me.him188.ani.datasources.api.paging.PagedSource
 import me.him188.ani.datasources.api.source.ConnectionStatus
 import me.him188.ani.datasources.api.source.DownloadSearchQuery
+import me.him188.ani.datasources.api.source.FactoryId
 import me.him188.ani.datasources.api.source.MediaSource
 import me.him188.ani.datasources.api.source.MediaSourceConfig
 import me.him188.ani.datasources.api.source.MediaSourceFactory
@@ -53,10 +54,9 @@ class AcgRipMediaSource(
     config: MediaSourceConfig,
 ) : TopicMediaSource() {
     class Factory : MediaSourceFactory {
-        override val mediaSourceId: String get() = ID
+        override val factoryId: FactoryId get() = FactoryId(ID)
         override val info: MediaSourceInfo get() = INFO
-
-        override fun create(config: MediaSourceConfig): MediaSource = AcgRipMediaSource(config)
+        override fun create(mediaSourceId: String, config: MediaSourceConfig): MediaSource = AcgRipMediaSource(config)
     }
 
     companion object {

--- a/data-sources/bt/dmhy/src/DmhyMediaSource.kt
+++ b/data-sources/bt/dmhy/src/DmhyMediaSource.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.CancellationException
 import me.him188.ani.datasources.api.paging.PagedSource
 import me.him188.ani.datasources.api.source.ConnectionStatus
 import me.him188.ani.datasources.api.source.DownloadSearchQuery
+import me.him188.ani.datasources.api.source.FactoryId
 import me.him188.ani.datasources.api.source.MediaSource
 import me.him188.ani.datasources.api.source.MediaSourceConfig
 import me.him188.ani.datasources.api.source.MediaSourceFactory
@@ -37,9 +38,9 @@ class DmhyMediaSource(
     config: MediaSourceConfig,
 ) : TopicMediaSource() {
     class Factory : MediaSourceFactory {
-        override val mediaSourceId: String = ID
+        override val factoryId: FactoryId = FactoryId(ID)
         override val info: MediaSourceInfo get() = INFO
-        override fun create(config: MediaSourceConfig): MediaSource = DmhyMediaSource(config)
+        override fun create(mediaSourceId: String, config: MediaSourceConfig): MediaSource = DmhyMediaSource(config)
     }
 
     companion object {

--- a/data-sources/bt/mikan/src/commonMain/kotlin/MikanMediaSource.kt
+++ b/data-sources/bt/mikan/src/commonMain/kotlin/MikanMediaSource.kt
@@ -35,6 +35,7 @@ import kotlinx.datetime.toInstant
 import me.him188.ani.datasources.api.paging.SinglePagePagedSource
 import me.him188.ani.datasources.api.paging.SizedSource
 import me.him188.ani.datasources.api.source.ConnectionStatus
+import me.him188.ani.datasources.api.source.FactoryId
 import me.him188.ani.datasources.api.source.HttpMediaSource
 import me.him188.ani.datasources.api.source.MatchKind
 import me.him188.ani.datasources.api.source.MediaFetchRequest
@@ -69,10 +70,11 @@ class MikanCNMediaSource(
     indexCacheProvider: MikanIndexCacheProvider = MemoryMikanIndexCacheProvider(),
 ) : AbstractMikanMediaSource(ID, config, BASE_URL, indexCacheProvider) {
     class Factory : MediaSourceFactory {
-        override val mediaSourceId: String get() = ID
+        override val factoryId: FactoryId get() = me.him188.ani.datasources.api.source.FactoryId(ID)
+
         override val info: MediaSourceInfo get() = INFO
 
-        override fun create(config: MediaSourceConfig): MediaSource =
+        override fun create(mediaSourceId: String, config: MediaSourceConfig): MediaSource =
             MikanCNMediaSource(config)
 
         fun create(
@@ -99,9 +101,10 @@ class MikanMediaSource(
     indexCacheProvider: MikanIndexCacheProvider = MemoryMikanIndexCacheProvider(),
 ) : AbstractMikanMediaSource(ID, config, BASE_URL, indexCacheProvider) {
     class Factory : MediaSourceFactory {
-        override val mediaSourceId: String get() = ID
+        override val factoryId: FactoryId get() = me.him188.ani.datasources.api.source.FactoryId(ID)
+
         override val info: MediaSourceInfo get() = INFO
-        override fun create(config: MediaSourceConfig): MediaSource = MikanMediaSource(config)
+        override fun create(mediaSourceId: String, config: MediaSourceConfig): MediaSource = MikanMediaSource(config)
 
         // TODO: this is actually not so good. We should generalize how MS can access caches.
         fun create(

--- a/data-sources/ikaros/src/IkarosMediaSource.kt
+++ b/data-sources/ikaros/src/IkarosMediaSource.kt
@@ -6,6 +6,7 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import me.him188.ani.datasources.api.paging.SizedSource
 import me.him188.ani.datasources.api.source.ConnectionStatus
+import me.him188.ani.datasources.api.source.FactoryId
 import me.him188.ani.datasources.api.source.HttpMediaSource
 import me.him188.ani.datasources.api.source.MediaFetchRequest
 import me.him188.ani.datasources.api.source.MediaMatch
@@ -21,7 +22,10 @@ import me.him188.ani.datasources.api.source.useHttpClient
 import java.nio.charset.StandardCharsets
 import java.util.Base64
 
-class IkarosMediaSource(config: MediaSourceConfig) : HttpMediaSource() {
+class IkarosMediaSource(
+    override val mediaSourceId: String,
+    config: MediaSourceConfig
+) : HttpMediaSource() {
     companion object {
         const val ID = "ikaros"
         val INFO = MediaSourceInfo(
@@ -58,16 +62,17 @@ class IkarosMediaSource(config: MediaSourceConfig) : HttpMediaSource() {
     }
 
     class Factory : MediaSourceFactory {
-        override val mediaSourceId: String get() = ID
+        override val factoryId: FactoryId get() = FactoryId(ID)
+
         override val parameters: MediaSourceParameters = Parameters.build()
         override val allowMultipleInstances: Boolean get() = true
-        override fun create(config: MediaSourceConfig): MediaSource = IkarosMediaSource(config)
+        override fun create(mediaSourceId: String, config: MediaSourceConfig): MediaSource =
+            IkarosMediaSource(mediaSourceId, config)
         override val info: MediaSourceInfo get() = INFO
     }
 
     override val kind: MediaSourceKind get() = MediaSourceKind.WEB
     override val info: MediaSourceInfo get() = INFO
-    override val mediaSourceId: String get() = ID
 
     override suspend fun checkConnection(): ConnectionStatus {
         return if ((HttpStatusCode.OK == client.checkConnection())

--- a/data-sources/jellyfin/src/EmbyMediaSource.kt
+++ b/data-sources/jellyfin/src/EmbyMediaSource.kt
@@ -1,5 +1,6 @@
 package me.him188.ani.datasources.jellyfin
 
+import me.him188.ani.datasources.api.source.FactoryId
 import me.him188.ani.datasources.api.source.MediaSource
 import me.him188.ani.datasources.api.source.MediaSourceConfig
 import me.him188.ani.datasources.api.source.MediaSourceFactory
@@ -23,7 +24,7 @@ class EmbyMediaSource(config: MediaSourceConfig) : BaseJellyfinMediaSource(confi
     object Parameters : MediaSourceParametersBuilder() {
         val baseUrl = string(
             "baseUrl",
-            default = "http://localhost:8096",
+            defaultProvider = { "http://localhost:8096" },
             description = "服务器地址\n示例: http://localhost:8096",
         )
         val userId = string(
@@ -37,11 +38,12 @@ class EmbyMediaSource(config: MediaSourceConfig) : BaseJellyfinMediaSource(confi
     }
 
     class Factory : MediaSourceFactory {
-        override val mediaSourceId: String get() = ID
+        override val factoryId: FactoryId get() = me.him188.ani.datasources.api.source.FactoryId(ID)
+
         override val parameters: MediaSourceParameters = Parameters.build()
         override val info: MediaSourceInfo get() = INFO
         override val allowMultipleInstances: Boolean get() = true
-        override fun create(config: MediaSourceConfig): MediaSource = EmbyMediaSource(config)
+        override fun create(mediaSourceId: String, config: MediaSourceConfig): MediaSource = EmbyMediaSource(config)
     }
 
     override val kind: MediaSourceKind get() = MediaSourceKind.WEB

--- a/data-sources/jellyfin/src/JellyfinMediaSource.kt
+++ b/data-sources/jellyfin/src/JellyfinMediaSource.kt
@@ -1,5 +1,6 @@
 package me.him188.ani.datasources.jellyfin
 
+import me.him188.ani.datasources.api.source.FactoryId
 import me.him188.ani.datasources.api.source.MediaSource
 import me.him188.ani.datasources.api.source.MediaSourceConfig
 import me.him188.ani.datasources.api.source.MediaSourceFactory
@@ -23,7 +24,7 @@ class JellyfinMediaSource(config: MediaSourceConfig) : BaseJellyfinMediaSource(c
     object Parameters : MediaSourceParametersBuilder() {
         val baseUrl = string(
             "baseUrl",
-            default = "http://localhost:8096",
+            defaultProvider = { "http://localhost:8096" },
             description = "服务器地址\n示例: http://localhost:8096",
         )
         val userId = string(
@@ -37,11 +38,12 @@ class JellyfinMediaSource(config: MediaSourceConfig) : BaseJellyfinMediaSource(c
     }
 
     class Factory : MediaSourceFactory {
-        override val mediaSourceId: String get() = ID
+        override val factoryId: FactoryId get() = FactoryId(ID)
+
         override val parameters: MediaSourceParameters = Parameters.build()
         override val info: MediaSourceInfo get() = INFO
         override val allowMultipleInstances: Boolean get() = true
-        override fun create(config: MediaSourceConfig): MediaSource = JellyfinMediaSource(config)
+        override fun create(mediaSourceId: String, config: MediaSourceConfig): MediaSource = JellyfinMediaSource(config)
     }
 
     override val kind: MediaSourceKind get() = MediaSourceKind.WEB

--- a/data-sources/web/gugufan/src/GugufanMediaSource.kt
+++ b/data-sources/web/gugufan/src/GugufanMediaSource.kt
@@ -7,6 +7,7 @@ import io.ktor.client.request.parameter
 import me.him188.ani.datasources.api.matcher.WebVideo
 import me.him188.ani.datasources.api.matcher.WebVideoMatcher
 import me.him188.ani.datasources.api.matcher.WebVideoMatcherContext
+import me.him188.ani.datasources.api.source.FactoryId
 import me.him188.ani.datasources.api.source.MediaFetchRequest
 import me.him188.ani.datasources.api.source.MediaSource
 import me.him188.ani.datasources.api.source.MediaSourceConfig
@@ -51,10 +52,11 @@ class GugufanMediaSource(config: MediaSourceConfig) : ThreeStepWebMediaSource() 
     }
 
     class Factory : MediaSourceFactory {
-        override val mediaSourceId: String get() = ID
+        override val factoryId: FactoryId get() = me.him188.ani.datasources.api.source.FactoryId(ID)
+
         override val info: MediaSourceInfo get() = INFO
 
-        override fun create(config: MediaSourceConfig): MediaSource = GugufanMediaSource(config)
+        override fun create(mediaSourceId: String, config: MediaSourceConfig): MediaSource = GugufanMediaSource(config)
     }
 
     override val baseUrl: String get() = BASE_URL

--- a/data-sources/web/mxdongman/src/MxdongmanMediaSource.kt
+++ b/data-sources/web/mxdongman/src/MxdongmanMediaSource.kt
@@ -6,6 +6,7 @@ import io.ktor.client.request.parameter
 import me.him188.ani.datasources.api.matcher.WebVideo
 import me.him188.ani.datasources.api.matcher.WebVideoMatcher
 import me.him188.ani.datasources.api.matcher.WebVideoMatcherContext
+import me.him188.ani.datasources.api.source.FactoryId
 import me.him188.ani.datasources.api.source.MediaFetchRequest
 import me.him188.ani.datasources.api.source.MediaSource
 import me.him188.ani.datasources.api.source.MediaSourceConfig
@@ -50,9 +51,11 @@ class MxdongmanMediaSource(config: MediaSourceConfig) : ThreeStepWebMediaSource(
     }
 
     class Factory : MediaSourceFactory {
-        override val mediaSourceId: String get() = ID
+        override val factoryId: FactoryId get() = me.him188.ani.datasources.api.source.FactoryId(ID)
+
         override val info: MediaSourceInfo get() = INFO
-        override fun create(config: MediaSourceConfig): MediaSource = MxdongmanMediaSource(config)
+        override fun create(mediaSourceId: String, config: MediaSourceConfig): MediaSource =
+            MxdongmanMediaSource(config)
     }
 
     override val baseUrl: String get() = BASE_URL

--- a/data-sources/web/ntdm/src/NtdmMediaSource.kt
+++ b/data-sources/web/ntdm/src/NtdmMediaSource.kt
@@ -7,6 +7,7 @@ import io.ktor.client.request.parameter
 import me.him188.ani.datasources.api.matcher.WebVideo
 import me.him188.ani.datasources.api.matcher.WebVideoMatcher
 import me.him188.ani.datasources.api.matcher.WebVideoMatcherContext
+import me.him188.ani.datasources.api.source.FactoryId
 import me.him188.ani.datasources.api.source.MediaFetchRequest
 import me.him188.ani.datasources.api.source.MediaSource
 import me.him188.ani.datasources.api.source.MediaSourceConfig
@@ -49,10 +50,11 @@ class NtdmMediaSource(config: MediaSourceConfig) : ThreeStepWebMediaSource() {
     }
 
     class Factory : MediaSourceFactory {
-        override val mediaSourceId: String get() = ID
+        override val factoryId: FactoryId get() = me.him188.ani.datasources.api.source.FactoryId(ID)
+
         override val info: MediaSourceInfo get() = INFO
 
-        override fun create(config: MediaSourceConfig): MediaSource = NtdmMediaSource(config)
+        override fun create(mediaSourceId: String, config: MediaSourceConfig): MediaSource = NtdmMediaSource(config)
     }
 
     override val baseUrl: String get() = BASE_URL

--- a/data-sources/web/nyafun/src/NyafunMediaSource.kt
+++ b/data-sources/web/nyafun/src/NyafunMediaSource.kt
@@ -24,6 +24,7 @@ import me.him188.ani.datasources.api.matcher.WebVideoMatcherContext
 import me.him188.ani.datasources.api.paging.SinglePagePagedSource
 import me.him188.ani.datasources.api.paging.SizedSource
 import me.him188.ani.datasources.api.source.ConnectionStatus
+import me.him188.ani.datasources.api.source.FactoryId
 import me.him188.ani.datasources.api.source.HttpMediaSource
 import me.him188.ani.datasources.api.source.MatchKind
 import me.him188.ani.datasources.api.source.MediaFetchRequest
@@ -40,7 +41,6 @@ import me.him188.ani.datasources.api.source.useHttpClient
 import me.him188.ani.datasources.api.topic.EpisodeRange
 import me.him188.ani.datasources.api.topic.FileSize
 import me.him188.ani.datasources.api.topic.ResourceLocation
-import me.him188.ani.utils.logging.info
 import me.him188.ani.utils.logging.warn
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
@@ -159,9 +159,10 @@ class NyafunMediaSource(config: MediaSourceConfig) : HttpMediaSource() {
     }
 
     class Factory : MediaSourceFactory {
-        override val mediaSourceId: String get() = ID
+        override val factoryId: FactoryId get() = me.him188.ani.datasources.api.source.FactoryId(ID)
+
         override val info: MediaSourceInfo get() = INFO
-        override fun create(config: MediaSourceConfig): MediaSource = NyafunMediaSource(config)
+        override fun create(mediaSourceId: String, config: MediaSourceConfig): MediaSource = NyafunMediaSource(config)
     }
 
     private val client by lazy {
@@ -213,7 +214,6 @@ class NyafunMediaSource(config: MediaSourceConfig) : HttpMediaSource() {
                         }
                         .toList()
 
-                    logger.info { "$ID fetched ${result.size} episodes for '$name': ${result.joinToString { it.media.episodeRange.toString() }}" }
                     result.asFlow()
                 }
         }

--- a/data-sources/web/xfdm/src/XfdmMediaSource.kt
+++ b/data-sources/web/xfdm/src/XfdmMediaSource.kt
@@ -7,6 +7,7 @@ import io.ktor.client.request.parameter
 import me.him188.ani.datasources.api.matcher.WebVideo
 import me.him188.ani.datasources.api.matcher.WebVideoMatcher
 import me.him188.ani.datasources.api.matcher.WebVideoMatcherContext
+import me.him188.ani.datasources.api.source.FactoryId
 import me.him188.ani.datasources.api.source.MediaFetchRequest
 import me.him188.ani.datasources.api.source.MediaSource
 import me.him188.ani.datasources.api.source.MediaSourceConfig
@@ -59,9 +60,10 @@ class XfdmMediaSource(
     override val baseUrl: String get() = BASE_URL
 
     class Factory : MediaSourceFactory {
-        override val mediaSourceId: String get() = ID
+        override val factoryId: FactoryId get() = me.him188.ani.datasources.api.source.FactoryId(ID)
 
-        override fun create(config: MediaSourceConfig): MediaSource =
+
+        override fun create(mediaSourceId: String, config: MediaSourceConfig): MediaSource =
             XfdmMediaSource(config)
 
         override val info: MediaSourceInfo = INFO


### PR DESCRIPTION
现在架构为每个 factory 用 factoryId 区分, 不涉及 mediaSourceId. Factory 可以构造多个 mediaSourceId 不同的 MediaSource. 在 APP, MediaSourceManager 使用 MediaSourceSave 存储数据源的配置等信息, 然后用这些信息, 调用正确的 factory, 构造 MediaSource. 这些信息在内存中为 MediaSourceInstance.

- MediaSourceFactory 的 mediaSourceId 改为 factoryId

在以前, 一个模板如果创建两个实例, 就会有问题

----

改动非常基础, 需要一个 alpha 版本测试, 3.9.0-alpha01