### PR TITLE
当且仅当收到 onTorrentChecked 和 onMetadataReceived 时 load files

### DIFF
--- a/torrent/anitorrent/gen/cpp/anitorrent_wrap.cpp
+++ b/torrent/anitorrent/gen/cpp/anitorrent_wrap.cpp
@@ -2540,6 +2540,21 @@ SWIGEXPORT jboolean JNICALL Java_me_him188_ani_app_torrent_anitorrent_binding_an
 }
 
 
+SWIGEXPORT jint JNICALL Java_me_him188_ani_app_torrent_anitorrent_binding_anitorrentJNI_torrent_1handle_1t_1get_1state(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_) {
+  jint jresult = 0 ;
+  anilt::torrent_handle_t *arg1 = (anilt::torrent_handle_t *) 0 ;
+  int result;
+  
+  (void)jenv;
+  (void)jcls;
+  (void)jarg1_;
+  arg1 = *(anilt::torrent_handle_t **)&jarg1; 
+  result = (int)((anilt::torrent_handle_t const *)arg1)->get_state();
+  jresult = (jint)result; 
+  return jresult;
+}
+
+
 SWIGEXPORT void JNICALL Java_me_him188_ani_app_torrent_anitorrent_binding_anitorrentJNI_torrent_1handle_1t_1post_1status_1updates(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_) {
   anilt::torrent_handle_t *arg1 = (anilt::torrent_handle_t *) 0 ;
   

--- a/torrent/anitorrent/gen/cpp/anitorrent_wrap.cpp
+++ b/torrent/anitorrent/gen/cpp/anitorrent_wrap.cpp
@@ -782,7 +782,7 @@ namespace Swig {
 namespace Swig {
   namespace {
     jclass jclass_anitorrentJNI = NULL;
-    jmethodID director_method_ids[11];
+    jmethodID director_method_ids[12];
   }
 }
 
@@ -1518,20 +1518,45 @@ void SwigDirector_event_listener_t::on_checked(anilt::handle_id_t handle_id) {
   if (swigjobj) jenv->DeleteLocalRef(swigjobj);
 }
 
-void SwigDirector_event_listener_t::on_torrent_added(anilt::handle_id_t handle_id) {
+void SwigDirector_event_listener_t::on_metadata_received(anilt::handle_id_t handle_id) {
   JNIEnvWrapper swigjnienv(this) ;
   JNIEnv * jenv = swigjnienv.getJNIEnv() ;
   jobject swigjobj = (jobject) NULL ;
   jlong jhandle_id  ;
   
   if (!swig_override[1]) {
-    anilt::event_listener_t::on_torrent_added(handle_id);
+    anilt::event_listener_t::on_metadata_received(handle_id);
     return;
   }
   swigjobj = swig_get_self(jenv);
   if (swigjobj && jenv->IsSameObject(swigjobj, NULL) == JNI_FALSE) {
     jhandle_id = (jlong) handle_id;
     jenv->CallStaticVoidMethod(Swig::jclass_anitorrentJNI, Swig::director_method_ids[1], swigjobj, jhandle_id);
+    jthrowable swigerror = jenv->ExceptionOccurred();
+    if (swigerror) {
+      Swig::DirectorException::raise(jenv, swigerror);
+    }
+    
+  } else {
+    SWIG_JavaThrowException(jenv, SWIG_JavaNullPointerException, "null upcall object in anilt::event_listener_t::on_metadata_received ");
+  }
+  if (swigjobj) jenv->DeleteLocalRef(swigjobj);
+}
+
+void SwigDirector_event_listener_t::on_torrent_added(anilt::handle_id_t handle_id) {
+  JNIEnvWrapper swigjnienv(this) ;
+  JNIEnv * jenv = swigjnienv.getJNIEnv() ;
+  jobject swigjobj = (jobject) NULL ;
+  jlong jhandle_id  ;
+  
+  if (!swig_override[2]) {
+    anilt::event_listener_t::on_torrent_added(handle_id);
+    return;
+  }
+  swigjobj = swig_get_self(jenv);
+  if (swigjobj && jenv->IsSameObject(swigjobj, NULL) == JNI_FALSE) {
+    jhandle_id = (jlong) handle_id;
+    jenv->CallStaticVoidMethod(Swig::jclass_anitorrentJNI, Swig::director_method_ids[2], swigjobj, jhandle_id);
     jthrowable swigerror = jenv->ExceptionOccurred();
     if (swigerror) {
       Swig::DirectorException::raise(jenv, swigerror);
@@ -1550,7 +1575,7 @@ void SwigDirector_event_listener_t::on_save_resume_data(anilt::handle_id_t handl
   jlong jhandle_id  ;
   jlong jdata = 0 ;
   
-  if (!swig_override[2]) {
+  if (!swig_override[3]) {
     anilt::event_listener_t::on_save_resume_data(handle_id,data);
     return;
   }
@@ -1558,7 +1583,7 @@ void SwigDirector_event_listener_t::on_save_resume_data(anilt::handle_id_t handl
   if (swigjobj && jenv->IsSameObject(swigjobj, NULL) == JNI_FALSE) {
     jhandle_id = (jlong) handle_id;
     *(anilt::torrent_resume_data_t **)&jdata = (anilt::torrent_resume_data_t *) &data; 
-    jenv->CallStaticVoidMethod(Swig::jclass_anitorrentJNI, Swig::director_method_ids[2], swigjobj, jhandle_id, jdata);
+    jenv->CallStaticVoidMethod(Swig::jclass_anitorrentJNI, Swig::director_method_ids[3], swigjobj, jhandle_id, jdata);
     jthrowable swigerror = jenv->ExceptionOccurred();
     if (swigerror) {
       Swig::DirectorException::raise(jenv, swigerror);
@@ -1577,7 +1602,7 @@ void SwigDirector_event_listener_t::on_torrent_state_changed(anilt::handle_id_t 
   jlong jhandle_id  ;
   jint jstate  ;
   
-  if (!swig_override[3]) {
+  if (!swig_override[4]) {
     anilt::event_listener_t::on_torrent_state_changed(handle_id,state);
     return;
   }
@@ -1585,7 +1610,7 @@ void SwigDirector_event_listener_t::on_torrent_state_changed(anilt::handle_id_t 
   if (swigjobj && jenv->IsSameObject(swigjobj, NULL) == JNI_FALSE) {
     jhandle_id = (jlong) handle_id;
     jstate = (jint) state;
-    jenv->CallStaticVoidMethod(Swig::jclass_anitorrentJNI, Swig::director_method_ids[3], swigjobj, jhandle_id, jstate);
+    jenv->CallStaticVoidMethod(Swig::jclass_anitorrentJNI, Swig::director_method_ids[4], swigjobj, jhandle_id, jstate);
     jthrowable swigerror = jenv->ExceptionOccurred();
     if (swigerror) {
       Swig::DirectorException::raise(jenv, swigerror);
@@ -1605,7 +1630,7 @@ void SwigDirector_event_listener_t::on_block_downloading(anilt::handle_id_t hand
   jint jpiece_index  ;
   jint jblock_index  ;
   
-  if (!swig_override[4]) {
+  if (!swig_override[5]) {
     anilt::event_listener_t::on_block_downloading(handle_id,piece_index,block_index);
     return;
   }
@@ -1614,7 +1639,7 @@ void SwigDirector_event_listener_t::on_block_downloading(anilt::handle_id_t hand
     jhandle_id = (jlong) handle_id;
     jpiece_index = (jint) piece_index;
     jblock_index = (jint) block_index;
-    jenv->CallStaticVoidMethod(Swig::jclass_anitorrentJNI, Swig::director_method_ids[4], swigjobj, jhandle_id, jpiece_index, jblock_index);
+    jenv->CallStaticVoidMethod(Swig::jclass_anitorrentJNI, Swig::director_method_ids[5], swigjobj, jhandle_id, jpiece_index, jblock_index);
     jthrowable swigerror = jenv->ExceptionOccurred();
     if (swigerror) {
       Swig::DirectorException::raise(jenv, swigerror);
@@ -1633,7 +1658,7 @@ void SwigDirector_event_listener_t::on_piece_finished(anilt::handle_id_t handle_
   jlong jhandle_id  ;
   jint jpiece_index  ;
   
-  if (!swig_override[5]) {
+  if (!swig_override[6]) {
     anilt::event_listener_t::on_piece_finished(handle_id,piece_index);
     return;
   }
@@ -1641,7 +1666,7 @@ void SwigDirector_event_listener_t::on_piece_finished(anilt::handle_id_t handle_
   if (swigjobj && jenv->IsSameObject(swigjobj, NULL) == JNI_FALSE) {
     jhandle_id = (jlong) handle_id;
     jpiece_index = (jint) piece_index;
-    jenv->CallStaticVoidMethod(Swig::jclass_anitorrentJNI, Swig::director_method_ids[5], swigjobj, jhandle_id, jpiece_index);
+    jenv->CallStaticVoidMethod(Swig::jclass_anitorrentJNI, Swig::director_method_ids[6], swigjobj, jhandle_id, jpiece_index);
     jthrowable swigerror = jenv->ExceptionOccurred();
     if (swigerror) {
       Swig::DirectorException::raise(jenv, swigerror);
@@ -1660,7 +1685,7 @@ void SwigDirector_event_listener_t::on_status_update(anilt::handle_id_t handle_i
   jlong jhandle_id  ;
   jlong jstats = 0 ;
   
-  if (!swig_override[6]) {
+  if (!swig_override[7]) {
     anilt::event_listener_t::on_status_update(handle_id,stats);
     return;
   }
@@ -1668,7 +1693,7 @@ void SwigDirector_event_listener_t::on_status_update(anilt::handle_id_t handle_i
   if (swigjobj && jenv->IsSameObject(swigjobj, NULL) == JNI_FALSE) {
     jhandle_id = (jlong) handle_id;
     *(anilt::torrent_stats_t **)&jstats = (anilt::torrent_stats_t *) &stats; 
-    jenv->CallStaticVoidMethod(Swig::jclass_anitorrentJNI, Swig::director_method_ids[6], swigjobj, jhandle_id, jstats);
+    jenv->CallStaticVoidMethod(Swig::jclass_anitorrentJNI, Swig::director_method_ids[7], swigjobj, jhandle_id, jstats);
     jthrowable swigerror = jenv->ExceptionOccurred();
     if (swigerror) {
       Swig::DirectorException::raise(jenv, swigerror);
@@ -1687,7 +1712,7 @@ void SwigDirector_event_listener_t::on_file_completed(anilt::handle_id_t handle_
   jlong jhandle_id  ;
   jint jfile_index  ;
   
-  if (!swig_override[7]) {
+  if (!swig_override[8]) {
     anilt::event_listener_t::on_file_completed(handle_id,file_index);
     return;
   }
@@ -1695,7 +1720,7 @@ void SwigDirector_event_listener_t::on_file_completed(anilt::handle_id_t handle_
   if (swigjobj && jenv->IsSameObject(swigjobj, NULL) == JNI_FALSE) {
     jhandle_id = (jlong) handle_id;
     jfile_index = (jint) file_index;
-    jenv->CallStaticVoidMethod(Swig::jclass_anitorrentJNI, Swig::director_method_ids[7], swigjobj, jhandle_id, jfile_index);
+    jenv->CallStaticVoidMethod(Swig::jclass_anitorrentJNI, Swig::director_method_ids[8], swigjobj, jhandle_id, jfile_index);
     jthrowable swigerror = jenv->ExceptionOccurred();
     if (swigerror) {
       Swig::DirectorException::raise(jenv, swigerror);
@@ -1714,7 +1739,7 @@ void SwigDirector_event_listener_t::on_torrent_removed(anilt::handle_id_t handle
   jlong jhandle_id  ;
   jstring jtorrent_name = 0 ;
   
-  if (!swig_override[8]) {
+  if (!swig_override[9]) {
     anilt::event_listener_t::on_torrent_removed(handle_id,torrent_name);
     return;
   }
@@ -1727,7 +1752,7 @@ void SwigDirector_event_listener_t::on_torrent_removed(anilt::handle_id_t handle
       if (!jtorrent_name) return ;
     }
     Swig::LocalRefGuard torrent_name_refguard(jenv, jtorrent_name);
-    jenv->CallStaticVoidMethod(Swig::jclass_anitorrentJNI, Swig::director_method_ids[8], swigjobj, jhandle_id, jtorrent_name);
+    jenv->CallStaticVoidMethod(Swig::jclass_anitorrentJNI, Swig::director_method_ids[9], swigjobj, jhandle_id, jtorrent_name);
     jthrowable swigerror = jenv->ExceptionOccurred();
     if (swigerror) {
       Swig::DirectorException::raise(jenv, swigerror);
@@ -1746,7 +1771,7 @@ void SwigDirector_event_listener_t::on_session_stats(anilt::handle_id_t handle_i
   jlong jhandle_id  ;
   jlong jstats = 0 ;
   
-  if (!swig_override[9]) {
+  if (!swig_override[10]) {
     anilt::event_listener_t::on_session_stats(handle_id,stats);
     return;
   }
@@ -1754,7 +1779,7 @@ void SwigDirector_event_listener_t::on_session_stats(anilt::handle_id_t handle_i
   if (swigjobj && jenv->IsSameObject(swigjobj, NULL) == JNI_FALSE) {
     jhandle_id = (jlong) handle_id;
     *(anilt::session_stats_t **)&jstats = (anilt::session_stats_t *) &stats; 
-    jenv->CallStaticVoidMethod(Swig::jclass_anitorrentJNI, Swig::director_method_ids[9], swigjobj, jhandle_id, jstats);
+    jenv->CallStaticVoidMethod(Swig::jclass_anitorrentJNI, Swig::director_method_ids[10], swigjobj, jhandle_id, jstats);
     jthrowable swigerror = jenv->ExceptionOccurred();
     if (swigerror) {
       Swig::DirectorException::raise(jenv, swigerror);
@@ -1771,6 +1796,7 @@ void SwigDirector_event_listener_t::swig_connect_director(JNIEnv *jenv, jobject 
   if (!baseclass) return;
   static SwigDirectorMethod methods[] = {
     SwigDirectorMethod(jenv, baseclass, "on_checked", "(J)V"),
+    SwigDirectorMethod(jenv, baseclass, "on_metadata_received", "(J)V"),
     SwigDirectorMethod(jenv, baseclass, "on_torrent_added", "(J)V"),
     SwigDirectorMethod(jenv, baseclass, "on_save_resume_data", "(JLme/him188/ani/app/torrent/anitorrent/binding/torrent_resume_data_t;)V"),
     SwigDirectorMethod(jenv, baseclass, "on_torrent_state_changed", "(JLme/him188/ani/app/torrent/anitorrent/binding/torrent_state_t;)V"),
@@ -1784,7 +1810,7 @@ void SwigDirector_event_listener_t::swig_connect_director(JNIEnv *jenv, jobject 
   
   if (swig_set_self(jenv, jself, swig_mem_own, weak_global)) {
     bool derived = (jenv->IsSameObject(baseclass, jcls) ? false : true);
-    for (int i = 0; i < 10; ++i) {
+    for (int i = 0; i < 11; ++i) {
       swig_override[i] = false;
       if (derived) {
         jmethodID methid = jenv->GetMethodID(jcls, methods[i].name, methods[i].desc);
@@ -1815,7 +1841,7 @@ void SwigDirector_new_event_listener_t::on_new_events() {
   }
   swigjobj = swig_get_self(jenv);
   if (swigjobj && jenv->IsSameObject(swigjobj, NULL) == JNI_FALSE) {
-    jenv->CallStaticVoidMethod(Swig::jclass_anitorrentJNI, Swig::director_method_ids[10], swigjobj);
+    jenv->CallStaticVoidMethod(Swig::jclass_anitorrentJNI, Swig::director_method_ids[11], swigjobj);
     jthrowable swigerror = jenv->ExceptionOccurred();
     if (swigerror) {
       Swig::DirectorException::raise(jenv, swigerror);
@@ -3278,6 +3304,32 @@ SWIGEXPORT void JNICALL Java_me_him188_ani_app_torrent_anitorrent_binding_anitor
 }
 
 
+SWIGEXPORT void JNICALL Java_me_him188_ani_app_torrent_anitorrent_binding_anitorrentJNI_event_1listener_1t_1on_1metadata_1received(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_, jlong jarg2) {
+  anilt::event_listener_t *arg1 = (anilt::event_listener_t *) 0 ;
+  anilt::handle_id_t arg2 ;
+  
+  (void)jenv;
+  (void)jcls;
+  (void)jarg1_;
+  arg1 = *(anilt::event_listener_t **)&jarg1; 
+  arg2 = (anilt::handle_id_t)jarg2; 
+  (arg1)->on_metadata_received(arg2);
+}
+
+
+SWIGEXPORT void JNICALL Java_me_him188_ani_app_torrent_anitorrent_binding_anitorrentJNI_event_1listener_1t_1on_1metadata_1receivedSwigExplicitevent_1listener_1t(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_, jlong jarg2) {
+  anilt::event_listener_t *arg1 = (anilt::event_listener_t *) 0 ;
+  anilt::handle_id_t arg2 ;
+  
+  (void)jenv;
+  (void)jcls;
+  (void)jarg1_;
+  arg1 = *(anilt::event_listener_t **)&jarg1; 
+  arg2 = (anilt::handle_id_t)jarg2; 
+  (arg1)->anilt::event_listener_t::on_metadata_received(arg2);
+}
+
+
 SWIGEXPORT void JNICALL Java_me_him188_ani_app_torrent_anitorrent_binding_anitorrentJNI_event_1listener_1t_1on_1torrent_1added(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_, jlong jarg2) {
   anilt::event_listener_t *arg1 = (anilt::event_listener_t *) 0 ;
   anilt::handle_id_t arg2 ;
@@ -4262,9 +4314,12 @@ SWIGEXPORT void JNICALL Java_me_him188_ani_app_torrent_anitorrent_binding_anitor
   static struct {
     const char *method;
     const char *signature;
-  } methods[11] = {
+  } methods[12] = {
     {
       "SwigDirector_event_listener_t_on_checked", "(Lme/him188/ani/app/torrent/anitorrent/binding/event_listener_t;J)V" 
+    },
+    {
+      "SwigDirector_event_listener_t_on_metadata_received", "(Lme/him188/ani/app/torrent/anitorrent/binding/event_listener_t;J)V" 
     },
     {
       "SwigDirector_event_listener_t_on_torrent_added", "(Lme/him188/ani/app/torrent/anitorrent/binding/event_listener_t;J)V" 

--- a/torrent/anitorrent/gen/cpp/anitorrent_wrap.h
+++ b/torrent/anitorrent/gen/cpp/anitorrent_wrap.h
@@ -17,6 +17,7 @@ public:
     SwigDirector_event_listener_t(JNIEnv *jenv);
     virtual ~SwigDirector_event_listener_t();
     virtual void on_checked(anilt::handle_id_t handle_id);
+    virtual void on_metadata_received(anilt::handle_id_t handle_id);
     virtual void on_torrent_added(anilt::handle_id_t handle_id);
     virtual void on_save_resume_data(anilt::handle_id_t handle_id,anilt::torrent_resume_data_t &data);
     virtual void on_torrent_state_changed(anilt::handle_id_t handle_id,anilt::torrent_state_t state);
@@ -28,10 +29,10 @@ public:
     virtual void on_session_stats(anilt::handle_id_t handle_id,anilt::session_stats_t &stats);
 public:
     bool swig_overrides(int n) {
-      return (n < 10 ? swig_override[n] : false);
+      return (n < 11 ? swig_override[n] : false);
     }
 protected:
-    Swig::BoolArray<10> swig_override;
+    Swig::BoolArray<11> swig_override;
 };
 
 class SwigDirector_new_event_listener_t : public anilt::new_event_listener_t, public Swig::Director {

--- a/torrent/anitorrent/gen/java/me/him188/ani/app/torrent/anitorrent/binding/anitorrentJNI.java
+++ b/torrent/anitorrent/gen/java/me/him188/ani/app/torrent/anitorrent/binding/anitorrentJNI.java
@@ -111,6 +111,8 @@ public class anitorrentJNI {
   public final static native void delete_event_listener_t(long jarg1);
   public final static native void event_listener_t_on_checked(long jarg1, event_listener_t jarg1_, long jarg2);
   public final static native void event_listener_t_on_checkedSwigExplicitevent_listener_t(long jarg1, event_listener_t jarg1_, long jarg2);
+  public final static native void event_listener_t_on_metadata_received(long jarg1, event_listener_t jarg1_, long jarg2);
+  public final static native void event_listener_t_on_metadata_receivedSwigExplicitevent_listener_t(long jarg1, event_listener_t jarg1_, long jarg2);
   public final static native void event_listener_t_on_torrent_added(long jarg1, event_listener_t jarg1_, long jarg2);
   public final static native void event_listener_t_on_torrent_addedSwigExplicitevent_listener_t(long jarg1, event_listener_t jarg1_, long jarg2);
   public final static native void event_listener_t_on_save_resume_data(long jarg1, event_listener_t jarg1_, long jarg2, long jarg3, torrent_resume_data_t jarg3_);
@@ -179,6 +181,9 @@ public class anitorrentJNI {
 
   public static void SwigDirector_event_listener_t_on_checked(event_listener_t jself, long handle_id) {
     jself.on_checked(handle_id);
+  }
+  public static void SwigDirector_event_listener_t_on_metadata_received(event_listener_t jself, long handle_id) {
+    jself.on_metadata_received(handle_id);
   }
   public static void SwigDirector_event_listener_t_on_torrent_added(event_listener_t jself, long handle_id) {
     jself.on_torrent_added(handle_id);

--- a/torrent/anitorrent/gen/java/me/him188/ani/app/torrent/anitorrent/binding/anitorrentJNI.java
+++ b/torrent/anitorrent/gen/java/me/him188/ani/app/torrent/anitorrent/binding/anitorrentJNI.java
@@ -57,6 +57,7 @@ public class anitorrentJNI {
   public final static native int torrent_handle_t_kReloadFileSuccess_get();
   public final static native int torrent_handle_t_reload_file(long jarg1, torrent_handle_t jarg1_);
   public final static native boolean torrent_handle_t_is_valid(long jarg1, torrent_handle_t jarg1_);
+  public final static native int torrent_handle_t_get_state(long jarg1, torrent_handle_t jarg1_);
   public final static native void torrent_handle_t_post_status_updates(long jarg1, torrent_handle_t jarg1_);
   public final static native void torrent_handle_t_post_save_resume(long jarg1, torrent_handle_t jarg1_);
   public final static native void torrent_handle_t_post_file_progress(long jarg1, torrent_handle_t jarg1_);

--- a/torrent/anitorrent/gen/java/me/him188/ani/app/torrent/anitorrent/binding/event_listener_t.java
+++ b/torrent/anitorrent/gen/java/me/him188/ani/app/torrent/anitorrent/binding/event_listener_t.java
@@ -68,6 +68,10 @@ public class event_listener_t {
     if (getClass() == event_listener_t.class) anitorrentJNI.event_listener_t_on_checked(swigCPtr, this, handle_id); else anitorrentJNI.event_listener_t_on_checkedSwigExplicitevent_listener_t(swigCPtr, this, handle_id);
   }
 
+  public void on_metadata_received(long handle_id) {
+    if (getClass() == event_listener_t.class) anitorrentJNI.event_listener_t_on_metadata_received(swigCPtr, this, handle_id); else anitorrentJNI.event_listener_t_on_metadata_receivedSwigExplicitevent_listener_t(swigCPtr, this, handle_id);
+  }
+
   public void on_torrent_added(long handle_id) {
     if (getClass() == event_listener_t.class) anitorrentJNI.event_listener_t_on_torrent_added(swigCPtr, this, handle_id); else anitorrentJNI.event_listener_t_on_torrent_addedSwigExplicitevent_listener_t(swigCPtr, this, handle_id);
   }

--- a/torrent/anitorrent/gen/java/me/him188/ani/app/torrent/anitorrent/binding/torrent_handle_t.java
+++ b/torrent/anitorrent/gen/java/me/him188/ani/app/torrent/anitorrent/binding/torrent_handle_t.java
@@ -70,6 +70,10 @@ public class torrent_handle_t {
     return anitorrentJNI.torrent_handle_t_is_valid(swigCPtr, this);
   }
 
+  public int get_state() {
+    return anitorrentJNI.torrent_handle_t_get_state(swigCPtr, this);
+  }
+
   public void post_status_updates() {
     anitorrentJNI.torrent_handle_t_post_status_updates(swigCPtr, this);
   }

--- a/torrent/anitorrent/include/events.hpp
+++ b/torrent/anitorrent/include/events.hpp
@@ -109,6 +109,8 @@ class event_listener_t { // inherited from Kotlin
     virtual ~event_listener_t() = default;
 
     virtual void on_checked(handle_id_t handle_id) {}
+
+    virtual void on_metadata_received(handle_id_t handle_id) {}
     virtual void on_torrent_added(handle_id_t handle_id) {}
     virtual void on_save_resume_data(handle_id_t handle_id, torrent_resume_data_t &data) {}
     virtual void on_torrent_state_changed(handle_id_t handle_id, torrent_state_t state) {}

--- a/torrent/anitorrent/include/torrent_handle_t.hpp
+++ b/torrent/anitorrent/include/torrent_handle_t.hpp
@@ -25,6 +25,8 @@ class torrent_handle_t final {
 
     [[nodiscard]] bool is_valid() const;
 
+    int get_state() const;
+
     // See event_listener_t::on_status_update
     void post_status_updates() const;
     void post_save_resume() const;

--- a/torrent/anitorrent/src/events.cpp
+++ b/torrent/anitorrent/src/events.cpp
@@ -1,4 +1,4 @@
-
+﻿
 #include "events.hpp"
 
 #include <fstream>
@@ -70,6 +70,11 @@ void call_listener(lt::alert *alert, libtorrent::session &session, event_listene
     if (lt::alert_cast<lt::torrent_checked_alert>(torrent_alert)) {
         function_printer_t _fp("call_listener:torrent_checked_event_t");
         listener.on_checked(handle.id());
+        return;
+    }
+    if (lt::alert_cast<lt::metadata_received_alert>(torrent_alert)) {
+        function_printer_t _fp("call_listener:metadata_received_alert");
+        listener.on_metadata_received(handle.id());
         return;
     }
     if (const auto a = lt::alert_cast<lt::save_resume_data_alert>(torrent_alert)) {

--- a/torrent/anitorrent/src/torrent_handle_t.cpp
+++ b/torrent/anitorrent/src/torrent_handle_t.cpp
@@ -143,4 +143,11 @@ void torrent_handle_t::set_file_priority(const int index, const uint8_t priority
         }
         return "";
     }
+
+    int torrent_handle_t::get_state() const {
+        if (const auto handle = handle_; handle && handle->is_valid()) {
+            return handle->status().state;
+        }
+        return -1;
+    }
 } // namespace anilt

--- a/torrent/impl/anitorrent/src/commonMain/kotlin/session/AnitorrentDownloadSession.kt
+++ b/torrent/impl/anitorrent/src/commonMain/kotlin/session/AnitorrentDownloadSession.kt
@@ -331,23 +331,22 @@ class AnitorrentDownloadSession(
         reloadFilesAndInitializeIfNotYet()
     }
 
-    private fun reloadFilesAndInitializeIfNotYet() {
-        if (actualTorrentInfo.isActive) {
+    // 这个不一定会触发. 有可能是如果种子内已经有信息的就不会触发
+    fun onMetadataReceived() {
+        logger.info { "[$handleId] onMetadataReceived" }
+        reloadFilesAndInitializeIfNotYet()
+    }
+
+    private val reloadFilesLock = SynchronizedObject()
+    private fun reloadFilesAndInitializeIfNotYet() = synchronized(reloadFilesLock) {
+        val handleIsValid = handle.isValid
+        val metadataReady = handle.getState().isMetadataReady()
+        if (actualTorrentInfo.isActive && handleIsValid && metadataReady) {
             logger.info { "[$handleId] reloadFiles" }
-            val info = handle.reloadFile()
-            if (handle.getState().isProcessingMetadata()) {
-                logger.warn { "[$handleId] reloadFilesAndInitializeIfNotYet is called, but native is still processing metadata" }
-                // 文件还没找到, 等一会
-                scope.launch {
-                    delay(1000)
-                    reloadFilesAndInitializeIfNotYet() // TODO: thread safety 
-                }
-            }
-            initializeTorrentInfo(
-                info,
-            ) // split to multiple lines for debugging
+            val info = handle.reloadFile() // split to multiple lines for debugging
+            initializeTorrentInfo(info)
         } else {
-            logger.warn { "[$handleId] reloadFilesAndInitializeIfNotYet is called, but actualTorrentInfo is not active: $actualTorrentInfo" }
+            logger.debug { "[$handleId] reloadFiles condition not met, actualTorrentInfo=$actualTorrentInfo handleIsValid=$handleIsValid, metadataReady=$metadataReady" }
         }
     }
 
@@ -394,11 +393,11 @@ class AnitorrentDownloadSession(
         }
     }
 
+    // 这可能会被调用多次
     fun onTorrentFinished() {
         // 注意, 这个事件不一定是所有文件下载完成了. 
         // 在刚刚创建任务的时候所有文件都是完全不下载的状态, libtorrent 会立即广播这个事件.
         logger.info { "[$handleId] onTorrentFinished" }
-        reloadFilesAndInitializeIfNotYet()
         handle.postSaveResume()
     }
 
@@ -545,15 +544,15 @@ val TorrentDescriptor.fileSequence
 private fun calculateTotalFinishedSize(pieces: List<Piece>): Long =
     pieces.sumOf { if (it.state.value == PieceState.FINISHED) it.size else 0 }
 
-private fun TorrentHandleState.isProcessingMetadata(): Boolean {
+private fun TorrentHandleState.isMetadataReady(): Boolean {
     return when (this) {
-        TorrentHandleState.QUEUED_FOR_CHECKING -> true
-        TorrentHandleState.CHECKING_FILES -> true
-        TorrentHandleState.DOWNLOADING_METADATA -> true
-        TorrentHandleState.DOWNLOADING -> false
-        TorrentHandleState.FINISHED -> false
-        TorrentHandleState.SEEDING -> false
-        TorrentHandleState.ALLOCATING -> true
-        TorrentHandleState.CHECKING_RESUME_DATA -> true
+        TorrentHandleState.QUEUED_FOR_CHECKING -> false
+        TorrentHandleState.CHECKING_FILES -> false
+        TorrentHandleState.DOWNLOADING_METADATA -> false
+        TorrentHandleState.DOWNLOADING -> true
+        TorrentHandleState.FINISHED -> true
+        TorrentHandleState.SEEDING -> true
+        TorrentHandleState.ALLOCATING -> false
+        TorrentHandleState.CHECKING_RESUME_DATA -> false
     }
 }

--- a/torrent/impl/anitorrent/src/commonMain/kotlin/session/TorrentManagerSession.kt
+++ b/torrent/impl/anitorrent/src/commonMain/kotlin/session/TorrentManagerSession.kt
@@ -31,6 +31,7 @@ interface TorrentHandle {
     fun resume()
     fun setFilePriority(index: Int, priority: FilePriority)
 
+    fun getState(): TorrentHandleState
     fun reloadFile(): TorrentDescriptor
 
     fun setPieceDeadline(index: Int, deadline: Int)
@@ -39,6 +40,72 @@ interface TorrentHandle {
     fun addTracker(tracker: String, tier: Short = 0, failLimit: Short = 0)
 
     fun getMagnetUri(): String?
+}
+
+// v2::torrent_status::state_t
+enum class TorrentHandleState {
+    QUEUED_FOR_CHECKING,
+    CHECKING_FILES,
+    DOWNLOADING_METADATA,
+    DOWNLOADING,
+    FINISHED,
+    SEEDING,
+    ALLOCATING,
+    CHECKING_RESUME_DATA
+    /*
+    		// the different overall states a torrent can be in
+		enum state_t
+		{
+#if TORRENT_ABI_VERSION == 1
+			// The torrent is in the queue for being checked. But there
+			// currently is another torrent that are being checked.
+			// This torrent will wait for its turn.
+			queued_for_checking TORRENT_DEPRECATED_ENUM,
+#else
+			// internal
+			unused_enum_for_backwards_compatibility,
+#endif
+
+			// The torrent has not started its download yet, and is
+			// currently checking existing files.
+			checking_files,
+
+			// The torrent is trying to download metadata from peers.
+			// This implies the ut_metadata extension is in use.
+			downloading_metadata,
+
+			// The torrent is being downloaded. This is the state
+			// most torrents will be in most of the time. The progress
+			// meter will tell how much of the files that has been
+			// downloaded.
+			downloading,
+
+			// In this state the torrent has finished downloading but
+			// still doesn't have the entire torrent. i.e. some pieces
+			// are filtered and won't get downloaded.
+			finished,
+
+			// In this state the torrent has finished downloading and
+			// is a pure seeder.
+			seeding,
+
+			// If the torrent was started in full allocation mode, this
+			// indicates that the (disk) storage for the torrent is
+			// allocated.
+#if TORRENT_ABI_VERSION == 1
+			allocating TORRENT_DEPRECATED_ENUM,
+#else
+			unused_enum_for_backwards_compatibility_allocating,
+#endif
+
+			// The torrent is currently checking the fast resume data and
+			// comparing it to the files on disk. This is typically
+			// completed in a fraction of a second, but if you add a
+			// large number of torrents at once, they will queue up.
+			checking_resume_data
+		};
+
+     */
 }
 
 interface TorrentAddInfo {

--- a/torrent/impl/anitorrent/src/commonMain/kotlin/test/TestAnitorrentTorrentDownloader.kt
+++ b/torrent/impl/anitorrent/src/commonMain/kotlin/test/TestAnitorrentTorrentDownloader.kt
@@ -8,6 +8,7 @@ import me.him188.ani.app.torrent.anitorrent.session.TorrentAddInfo
 import me.him188.ani.app.torrent.anitorrent.session.TorrentDescriptor
 import me.him188.ani.app.torrent.anitorrent.session.TorrentFileInfo
 import me.him188.ani.app.torrent.anitorrent.session.TorrentHandle
+import me.him188.ani.app.torrent.anitorrent.session.TorrentHandleState
 import me.him188.ani.app.torrent.anitorrent.session.TorrentManagerSession
 import me.him188.ani.app.torrent.anitorrent.session.TorrentResumeData
 import me.him188.ani.app.torrent.anitorrent.session.TorrentStats
@@ -120,6 +121,7 @@ open class TestTorrentHandle(
     var started: Boolean = false
     lateinit var addInfo: TestTorrentAddInfo
     lateinit var saveDir: Path
+    var state: TorrentHandleState = TorrentHandleState.DOWNLOADING
 
     private fun dispatchEvent(block: (AnitorrentDownloadSession) -> Unit) {
         dispatchEvent(id, block)
@@ -146,6 +148,8 @@ open class TestTorrentHandle(
 
     override fun setFilePriority(index: Int, priority: FilePriority) {
     }
+
+    override fun getState(): TorrentHandleState = state
 
     protected var descriptor: TestTorrentDescriptor = TestTorrentDescriptor("test", 1024_000 / 1024, 1024, 1024).apply {
         files.add(TestTorrentFileInfo("test.mkv", "test.mkv", 1024_000))

--- a/torrent/impl/anitorrent/src/commonMain/kotlin/test/TestAnitorrentTorrentDownloader.kt
+++ b/torrent/impl/anitorrent/src/commonMain/kotlin/test/TestAnitorrentTorrentDownloader.kt
@@ -121,6 +121,8 @@ open class TestTorrentHandle(
     var started: Boolean = false
     lateinit var addInfo: TestTorrentAddInfo
     lateinit var saveDir: Path
+
+    @JvmField // clash
     var state: TorrentHandleState = TorrentHandleState.DOWNLOADING
 
     private fun dispatchEvent(block: (AnitorrentDownloadSession) -> Unit) {

--- a/torrent/impl/anitorrent/src/jvmMain/kotlin/AnitorrentTorrentDownloader.jvm.kt
+++ b/torrent/impl/anitorrent/src/jvmMain/kotlin/AnitorrentTorrentDownloader.jvm.kt
@@ -83,9 +83,33 @@ internal class SwigAnitorrentTorrentDownloader(
             }
         }
 
+        /*
+2024-08-28 19:44:22,030 [INFO ] AnitorrentTorrentDownloader: [14167745] AnitorrentDownloadSession created, adding 29 trackers
+2024-08-28 19:44:22,030 [INFO ] AnitorrentTorrentDownloader: withHandleTaskQueue: executed 1 delayed tasks
+2024-08-28 19:44:23,307 [INFO ] AnitorrentDownloadSession: [14167745] onMetadataReceived
+2024-08-28 19:44:23,309 [INFO ] AnitorrentDownloadSession: [14167745] onTorrentFinished
+2024-08-28 19:44:23,309 [INFO ] AnitorrentDownloadSession: [14167745] onTorrentFinished
+2024-08-28 19:44:23,310 [INFO ] AnitorrentDownloadSession: [14167745] onTorrentChecked
+2024-08-28 19:44:23,310 [INFO ] AnitorrentDownloadSession: [14167745] reloadFiles
+2024-08-28 19:44:23,311 [INFO ] AnitorrentDownloadSession: initializeTorrentInfo
+2024-08-28 19:44:23,311 [INFO ] AnitorrentDownloadSession: [14167745] File '[ANi] 深夜 Punch - 08 [1080P][Baha][WEB-DL][AAC AVC][CHT].mp4' piece initialized, 778 pieces, index range: 0..777, offset range: Piece(0..524287)..Piece(407371776..407818747)
+2024-08-28 19:44:23,311 [INFO ] AnitorrentDownloadSession: [14167745] Got torrent info: TorrentInfo(name=[ANi] 深夜 Punch - 08 [1080P][Baha][WEB-DL][AAC AVC][CHT].mp4, numPieces=778, entries.size=1)
+2024-08-28 19:44:23,312 [INFO ] AnitorrentDownloadSession: [14167745] saving resume data to: /Users/him188/Library/Caches/me.Him188.Ani-debug/torrent-data2/anitorrent/pieces/917960765/fastresume
+2024-08-28 19:44:23,313 [INFO ] TorrentVideoSource: TorrentVideoSource selected file: [ANi] 深夜 Punch - 08 [1080P][Baha][WEB-DL][AAC AVC][CHT].mp4
+2024-08-28 19:44:23,313 [INFO ] AnitorrentEntry: [14167745] Set file priority to HIGH: [ANi] 深夜 Punch - 08 [1080P][Baha][WEB-DL][AAC AVC][CHT].mp4
+         */
+
+        // 新旧都会触发这个, 见上面的 log, 但似乎有时候会收不到这个事件
         override fun on_checked(handleId: Long) {
             dispatchToSession(handleId) {
                 it.onTorrentChecked()
+            }
+        }
+
+        // 看起来只有新资源才会触发这个, 见上面的 log
+        override fun on_metadata_received(handleId: Long) {
+            dispatchToSession(handleId) {
+                it.onMetadataReceived()
             }
         }
 
@@ -105,6 +129,7 @@ internal class SwigAnitorrentTorrentDownloader(
             state ?: return
             dispatchToSession(handleId) {
                 if (state == torrent_state_t.finished) {
+                    // 注意, 这可能会调用多次
                     it.onTorrentFinished()
                 }
             }

--- a/torrent/impl/anitorrent/src/jvmMain/kotlin/session/SwigTorrentHandle.kt
+++ b/torrent/impl/anitorrent/src/jvmMain/kotlin/session/SwigTorrentHandle.kt
@@ -27,6 +27,14 @@ class SwigTorrentHandle(
         native.set_file_priority(index, priority.toLibtorrentValue())
     }
 
+    override fun getState(): TorrentHandleState {
+        val state = native._state
+        if (state == -1) {
+            error("Failed to get state, native returned -1 (session is invalid)")
+        }
+        return TorrentHandleState.entries[state]
+    }
+
     override fun reloadFile(): TorrentDescriptor {
         val res = native.reload_file()
         if (res != torrent_handle_t.reload_file_result_t.kReloadFileSuccess) {


### PR DESCRIPTION
onTorrentFinished 现在不再加载文件. 因为在刚刚添加任务的时候, 所有文件都是不下载的, libtorrent 会立即推送一个 finished 事件. 此时可能元数据还并没有加载完成, 于是同步 files 会获取到空列表, 进而导致 #813

close #833 