### PR TITLE
修复桌面端自动连播

### DIFF
--- a/app/shared/video-player/src/desktopMain/kotlin/ui/VideoPlayer.desktop.kt
+++ b/app/shared/video-player/src/desktopMain/kotlin/ui/VideoPlayer.desktop.kt
@@ -308,7 +308,7 @@ class VlcjVideoPlayerState(parentCoroutineContext: CoroutineContext) : PlayerSta
                     state.value = PlaybackState.PAUSED
                 }
 
-                override fun stopped(mediaPlayer: MediaPlayer) {
+                override fun finished(mediaPlayer: MediaPlayer) {
                     state.value = PlaybackState.FINISHED
                 }
 


### PR DESCRIPTION
fix #852
安卓端和桌面端finish状态设置时机不一致导致的