### PR TITLE
RSS 数据源单独在一个设置页设置

### DIFF
--- a/app/shared/src/androidMain/kotlin/ui/settings/tabs/network/EditMediaSourceDialog.android.kt
+++ b/app/shared/src/androidMain/kotlin/ui/settings/tabs/network/EditMediaSourceDialog.android.kt
@@ -5,7 +5,7 @@ import androidx.compose.ui.tooling.preview.PreviewLightDark
 import kotlinx.coroutines.flow.flowOf
 import me.him188.ani.app.ui.foundation.ProvideCompositionLocalsForPreview
 import me.him188.ani.app.ui.settings.tabs.media.source.EditMediaSourceDialog
-import me.him188.ani.app.ui.settings.tabs.media.source.EditType
+import me.him188.ani.app.ui.settings.tabs.media.source.EditMediaSourceMode
 import me.him188.ani.app.ui.settings.tabs.media.source.EditingMediaSource
 import me.him188.ani.datasources.api.source.FactoryId
 import me.him188.ani.datasources.api.source.MediaSourceConfig
@@ -28,11 +28,11 @@ private fun PreviewEditMediaSourceDialogNoConfig() {
                 ),
                 parameters = MediaSourceParameters.Empty,
                 persistedArguments = flowOf(MediaSourceConfig.Default),
-                editType = EditType.Add,
+                editMediaSourceMode = EditMediaSourceMode.Add,
+                onSave = {},
                 parentCoroutineContext = EmptyCoroutineContext,
             ),
-            onDismissRequest = {},
-            onConfirm = {},
+            {}
         )
     }
 }
@@ -59,11 +59,11 @@ private fun PreviewEditMediaSourceDialog() {
                     simpleEnum("dropdown", "a", "b", "c", default = "b", description = "这是一个下拉菜单")
                 },
                 persistedArguments = flowOf(MediaSourceConfig.Default),
-                editType = EditType.Add,
+                editMediaSourceMode = EditMediaSourceMode.Add,
+                onSave = {},
                 parentCoroutineContext = EmptyCoroutineContext,
             ),
-            onDismissRequest = {},
-            onConfirm = {},
+            {}
         )
     }
 }

--- a/app/shared/src/commonMain/kotlin/data/source/media/fetch/MediaSourceManager.kt
+++ b/app/shared/src/commonMain/kotlin/data/source/media/fetch/MediaSourceManager.kt
@@ -7,10 +7,13 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.shareIn
+import kotlinx.serialization.SerializationStrategy
+import kotlinx.serialization.json.JsonElement
 import me.him188.ani.app.data.models.preference.MediaSourceProxySettings
 import me.him188.ani.app.data.models.preference.ProxyAuthorization
 import me.him188.ani.app.data.models.preference.ProxyConfig
@@ -30,6 +33,7 @@ import me.him188.ani.datasources.api.source.MediaSource
 import me.him188.ani.datasources.api.source.MediaSourceConfig
 import me.him188.ani.datasources.api.source.MediaSourceFactory
 import me.him188.ani.datasources.api.source.MediaSourceInfo
+import me.him188.ani.datasources.api.source.serializeArguments
 import me.him188.ani.datasources.mikan.MikanCNMediaSource
 import me.him188.ani.datasources.mikan.MikanMediaSource
 import me.him188.ani.utils.coroutines.onReplacement
@@ -102,10 +106,25 @@ interface MediaSourceManager { // available by inject
         config: MediaSourceConfig
     )
 
+
+    /**
+     * deprecated.
+     */
     suspend fun updateConfig(instanceId: String, config: MediaSourceConfig)
     suspend fun setEnabled(instanceId: String, enabled: Boolean)
     suspend fun removeInstance(instanceId: String)
 }
+
+suspend fun MediaSourceManager.updateMediaSourceArguments(
+    instanceId: String,
+    arguments: JsonElement
+) = updateConfig(instanceId, instanceConfigFlow(instanceId).first().copy(serializedArguments = arguments))
+
+suspend fun <T> MediaSourceManager.updateMediaSourceArguments(
+    instanceId: String,
+    serializer: SerializationStrategy<T>,
+    arguments: T
+) = updateMediaSourceArguments(instanceId, MediaSourceConfig.serializeArguments(serializer, arguments))
 
 /**
  * 根据请求创建 [MediaFetchSession].

--- a/app/shared/src/commonMain/kotlin/navigation/AniNavigator.kt
+++ b/app/shared/src/commonMain/kotlin/navigation/AniNavigator.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.navigation.NavHostController
 import kotlinx.coroutines.CompletableDeferred
 import me.him188.ani.app.ui.settings.SettingsTab
+import me.him188.ani.datasources.api.source.FactoryId
 import org.koin.core.component.KoinComponent
 import org.koin.mp.KoinPlatform
 
@@ -89,6 +90,22 @@ interface AniNavigator {
 
     fun navigateSettings(tab: SettingsTab = SettingsTab.Default) {
         navigator.navigate("/settings?tab=${tab.ordinal}&back=true")
+    }
+
+    fun navigateEditMediaSource(
+        factoryId: FactoryId,
+        existingMediaSourceInstanceId: String?,
+    ) {
+        navigator.navigate(
+            buildString {
+                append("/settings/media-source/edit/")
+                append(factoryId.value)
+                existingMediaSourceInstanceId?.let {
+                    append("?existingMediaSourceInstanceId=")
+                    append(it)
+                }
+            },
+        )
     }
 
     fun navigateCaches() {

--- a/app/shared/src/commonMain/kotlin/ui/main/AniAppContentPortrait.kt
+++ b/app/shared/src/commonMain/kotlin/ui/main/AniAppContentPortrait.kt
@@ -21,6 +21,7 @@ import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
+import me.him188.ani.app.data.source.media.source.RssMediaSource
 import me.him188.ani.app.navigation.AniNavigator
 import me.him188.ani.app.navigation.LocalNavigator
 import me.him188.ani.app.platform.LocalContext
@@ -30,7 +31,6 @@ import me.him188.ani.app.ui.cache.CacheManagementViewModel
 import me.him188.ani.app.ui.cache.details.MediaCacheDetailsPage
 import me.him188.ani.app.ui.cache.details.MediaCacheDetailsPageViewModel
 import me.him188.ani.app.ui.foundation.animation.EmphasizedDecelerateEasing
-import me.him188.ani.app.ui.foundation.widgets.LocalToaster
 import me.him188.ani.app.ui.profile.BangumiOAuthViewModel
 import me.him188.ani.app.ui.profile.SettingsViewModel
 import me.him188.ani.app.ui.profile.auth.BangumiOAuthScene
@@ -40,12 +40,16 @@ import me.him188.ani.app.ui.profile.auth.WelcomeScene
 import me.him188.ani.app.ui.profile.auth.WelcomeViewModel
 import me.him188.ani.app.ui.settings.SettingsPage
 import me.him188.ani.app.ui.settings.SettingsTab
+import me.him188.ani.app.ui.settings.tabs.media.source.EditMediaSourceMode
+import me.him188.ani.app.ui.settings.tabs.media.source.EditRssMediaSourcePage
+import me.him188.ani.app.ui.settings.tabs.media.source.EditRssMediaSourceViewModel
 import me.him188.ani.app.ui.subject.cache.SubjectCacheScene
 import me.him188.ani.app.ui.subject.cache.SubjectCacheViewModelImpl
 import me.him188.ani.app.ui.subject.details.SubjectDetailsScene
 import me.him188.ani.app.ui.subject.details.SubjectDetailsViewModel
 import me.him188.ani.app.ui.subject.episode.EpisodeScene
 import me.him188.ani.app.ui.subject.episode.EpisodeViewModel
+import me.him188.ani.datasources.api.source.FactoryId
 import kotlin.math.roundToInt
 
 @Composable
@@ -244,6 +248,36 @@ fun AniAppContentPortrait(
                 // Don't use rememberViewModel to save memory
                 val vm = remember(subjectId) { SubjectCacheViewModelImpl(subjectId) }
                 SubjectCacheScene(vm, Modifier.desktopTitleBarPadding())
+            }
+            composable(
+                "/settings/media-source/edit/{factoryId}?existingMediaSourceInstanceId={existingMediaSourceInstanceId}",
+                arguments = listOf(
+                    navArgument("factoryId") { type = NavType.StringType },
+                    navArgument("existingMediaSourceInstanceId") { type = NavType.StringType },
+                ),
+                enterTransition = enterTransition,
+                exitTransition = exitTransition,
+                popEnterTransition = popEnterTransition,
+                popExitTransition = popExitTransition,
+            ) { backStackEntry ->
+                val factoryId = backStackEntry.arguments?.getString("factoryId") ?: kotlin.run {
+                    navController.popBackStack()
+                    return@composable
+                }
+                val mediaSourceInstanceId = backStackEntry.arguments?.getString("existingMediaSourceInstanceId")
+                when (FactoryId(factoryId)) {
+                    RssMediaSource.FactoryId -> EditRssMediaSourcePage(
+                        viewModel<EditRssMediaSourceViewModel>(key = mediaSourceInstanceId) {
+                            EditRssMediaSourceViewModel(
+                                if (mediaSourceInstanceId == null) EditMediaSourceMode.Add
+                                else EditMediaSourceMode.Edit(instanceId = mediaSourceInstanceId),
+                            )
+                        },
+                        Modifier.desktopTitleBarPadding()
+                    )
+
+                    else -> error("Unknown factoryId: $factoryId")
+                }
             }
         }
     }

--- a/app/shared/src/commonMain/kotlin/ui/settings/tabs/media/source/ConfimExitDialog.kt
+++ b/app/shared/src/commonMain/kotlin/ui/settings/tabs/media/source/ConfimExitDialog.kt
@@ -1,0 +1,69 @@
+package me.him188.ani.app.ui.settings.tabs.media.source
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+
+@Composable
+fun rememberConfirmDiscardChangeDialogState(
+    onConfirm: () -> Unit,
+): ConfirmDiscardChangeDialogState {
+    val onConfirmState by rememberUpdatedState(onConfirm)
+    return remember {
+        ConfirmDiscardChangeDialogState(onConfirmState)
+    }
+}
+
+@Stable
+class ConfirmDiscardChangeDialogState(
+    val onConfirm: () -> Unit,
+) {
+    internal var isVisible by mutableStateOf(false)
+        private set
+
+    fun show() {
+        isVisible = true
+    }
+
+    fun dismissDialog() {
+        isVisible = false
+    }
+
+    fun confirmDiscard() {
+        onConfirm()
+        dismissDialog()
+    }
+}
+
+@Composable
+fun ConfirmDiscardChangeDialog(
+    state: ConfirmDiscardChangeDialogState,
+    modifier: Modifier = Modifier,
+) {
+    if (state.isVisible) {
+        AlertDialog(
+            onDismissRequest = state::dismissDialog,
+            text = { Text("是否舍弃更改?") },
+            confirmButton = {
+                TextButton(onClick = state::confirmDiscard) {
+                    Text("舍弃", color = MaterialTheme.colorScheme.error)
+                }
+            },
+            modifier = modifier,
+            dismissButton = {
+                TextButton(onClick = state::dismissDialog) {
+                    Text("继续编辑")
+                }
+            },
+        )
+    }
+}

--- a/app/shared/src/commonMain/kotlin/ui/settings/tabs/media/source/EditMediaSourceLayout.kt
+++ b/app/shared/src/commonMain/kotlin/ui/settings/tabs/media/source/EditMediaSourceLayout.kt
@@ -13,6 +13,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.ProvideTextStyle
@@ -35,8 +36,10 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.map
+import me.him188.ani.app.tools.MonoTasker
 import me.him188.ani.app.ui.foundation.BackgroundScope
 import me.him188.ani.app.ui.foundation.HasBackgroundScope
+import me.him188.ani.app.ui.foundation.isInDebugMode
 import me.him188.ani.app.ui.settings.rendering.MediaSourceIcon
 import me.him188.ani.datasources.api.source.FactoryId
 import me.him188.ani.datasources.api.source.MediaSourceConfig
@@ -49,11 +52,11 @@ import me.him188.ani.datasources.api.source.parameter.StringParameter
 import kotlin.coroutines.CoroutineContext
 
 
-sealed class EditType {
-    data object Add : EditType()
+sealed class EditMediaSourceMode {
+    data object Add : EditMediaSourceMode()
     data class Edit(
         val instanceId: String,
-    ) : EditType()
+    ) : EditMediaSourceMode()
 }
 
 @Stable
@@ -63,15 +66,15 @@ class EditingMediaSource(
     val info: MediaSourceInfo,
     val parameters: MediaSourceParameters,
     persistedArguments: Flow<MediaSourceConfig>, // 加载会有延迟
-    val editType: EditType,
+    val editMediaSourceMode: EditMediaSourceMode,
+    private val onSave: suspend (EditingMediaSource) -> Unit, // background
     parentCoroutineContext: CoroutineContext,
 ) : HasBackgroundScope by BackgroundScope(parentCoroutineContext), Closeable {
     init {
-        check(if (editType is EditType.Edit) editingMediaSourceId != null else editingMediaSourceId == null) {
-            "Invalid edit type and editingMediaSourceId: $editType, $editingMediaSourceId"
+        check(if (editMediaSourceMode is EditMediaSourceMode.Edit) editingMediaSourceId != null else editingMediaSourceId == null) {
+            "Invalid edit type and editingMediaSourceId: $editMediaSourceMode, $editingMediaSourceId"
         }
     }
-
 
     val arguments = parameters.list.map { param ->
         when (param) {
@@ -93,6 +96,14 @@ class EditingMediaSource(
 
     override fun close() {
         backgroundScope.cancel()
+    }
+
+    private val saveTasker = MonoTasker(backgroundScope)
+    val isSaving = saveTasker.isRunning
+    fun save() {
+        saveTasker.launch {
+            onSave(this@EditingMediaSource)
+        }
     }
 }
 
@@ -153,13 +164,45 @@ class SimpleEnumArgumentState(
     override fun toPersisted() = value
 }
 
+// TODO: remove or replace with non-dialog one (dedicated page)
 @Composable
 internal fun EditMediaSourceDialog(
     state: EditingMediaSource,
-    onConfirm: () -> Unit,
     onDismissRequest: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    // TODO: check changed 
+//    val backHandler = LocalBackHandler.current
+//    val confirmDiscardDialog = rememberConfirmDiscardChangeDialogState {
+//        state.isChanged = false
+//        backHandler.onBackPressed()
+//    }
+//    ConfirmDiscardChangeDialog(confirmDiscardDialog)
+//
+//    BackHandler(enabled = state.isChanged) {
+//        confirmDiscardDialog.show()
+//    }
+
+//    Scaffold(
+//        modifier,
+//        topBar = {
+//            TopAppBar(
+//                title = {
+//                    when (state.editMediaSourceMode) {
+//                        is EditMediaSourceMode.Edit -> Text(state.info.displayName)
+//                        EditMediaSourceMode.Add -> Text("新建数据源")
+//                    }
+//                },
+//                navigationIcon = { TopAppBarGoBackButton() },
+//                actions = {
+//                    IconButton({ state.save() }, enabled = !state.hasError) {
+//                        Icon(Icons.Rounded.Save, contentDescription = "保存")
+//                    }
+//                },
+//            )
+//        },
+//    ) { paddingValues ->
+
     AlertDialog(
         onDismissRequest,
         title = {
@@ -176,30 +219,32 @@ internal fun EditMediaSourceDialog(
                 return@AlertDialog
             }
 
-            Column(
-                Modifier.verticalScroll(rememberScrollState()).padding(top = 16.dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                for (argument in state.arguments) {
-                    when (argument) {
-                        is BooleanArgumentState -> {
-                            BooleanArgument(argument)
-                        }
+            Column(Modifier.padding()) {
+                Column(
+                    Modifier.verticalScroll(rememberScrollState()).padding(top = 16.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    for (argument in state.arguments) {
+                        when (argument) {
+                            is BooleanArgumentState -> {
+                                BooleanArgument(argument)
+                            }
 
-                        is SimpleEnumArgumentState -> {
-                            SimpleEnumArgument(argument)
-                        }
+                            is SimpleEnumArgumentState -> {
+                                SimpleEnumArgument(argument)
+                            }
 
-                        is StringArgumentState -> {
-                            OutlinedTextField(
-                                value = argument.value,
-                                onValueChange = { argument.value = argument.parameter.sanitize(it) },
-                                label = { Text(argument.name) },
-                                placeholder = argument.parameter.placeholder?.let { { Text(it) } },
-                                supportingText = argument.description?.let { { Text(it) } },
-                                isError = argument.isError,
-                                shape = MaterialTheme.shapes.medium,
-                            )
+                            is StringArgumentState -> {
+                                OutlinedTextField(
+                                    value = argument.value,
+                                    onValueChange = { argument.value = argument.parameter.sanitize(it) },
+                                    label = { Text(argument.name) },
+                                    placeholder = argument.parameter.placeholder?.let { { Text(it) } },
+                                    supportingText = argument.description?.let { { Text(it) } },
+                                    isError = argument.isError,
+                                    shape = MaterialTheme.shapes.medium,
+                                )
+                            }
                         }
                     }
                 }
@@ -212,9 +257,9 @@ internal fun EditMediaSourceDialog(
                     !state.hasError
                 }
             }
-            when (state.editType) {
-                EditType.Add -> Button(onConfirm, enabled = canSave) { Text("添加") }
-                is EditType.Edit -> Button(onConfirm, enabled = canSave) { Text("保存") }
+            when (state.editMediaSourceMode) {
+                EditMediaSourceMode.Add -> Button({ state.save() }, enabled = canSave) { Text("添加") }
+                is EditMediaSourceMode.Edit -> Button({ state.save() }, enabled = canSave) { Text("保存") }
             }
         },
         dismissButton = {

--- a/app/shared/src/commonMain/kotlin/ui/settings/tabs/media/source/EditRssMediaSource.kt
+++ b/app/shared/src/commonMain/kotlin/ui/settings/tabs/media/source/EditRssMediaSource.kt
@@ -1,0 +1,281 @@
+package me.him188.ani.app.ui.settings.tabs.media.source
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Save
+import androidx.compose.material3.BottomSheetDefaults
+import androidx.compose.material3.Button
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.ProvideTextStyle
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.transformLatest
+import me.him188.ani.app.data.source.media.fetch.MediaSourceManager
+import me.him188.ani.app.data.source.media.fetch.updateMediaSourceArguments
+import me.him188.ani.app.data.source.media.source.RssMediaSource
+import me.him188.ani.app.data.source.media.source.RssMediaSourceArguments
+import me.him188.ani.app.navigation.LocalBackHandler
+import me.him188.ani.app.platform.navigation.BackHandler
+import me.him188.ani.app.tools.MonoTasker
+import me.him188.ani.app.ui.foundation.AbstractViewModel
+import me.him188.ani.app.ui.foundation.isInDebugMode
+import me.him188.ani.app.ui.foundation.widgets.TopAppBarGoBackButton
+import me.him188.ani.datasources.api.source.deserializeArgumentsOrNull
+import me.him188.ani.utils.platform.Uuid
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+
+class EditRssMediaSourceViewModel(
+    initialMode: EditMediaSourceMode
+) : AbstractViewModel(), KoinComponent {
+    private val mediaSourceManager: MediaSourceManager by inject()
+
+    private val mode: MutableStateFlow<EditMediaSourceMode> = MutableStateFlow(initialMode)
+
+    val onSave: suspend (String, RssMediaSourceArguments) -> Unit = { instanceId, arguments ->
+        mediaSourceManager.updateMediaSourceArguments(
+            instanceId,
+            RssMediaSourceArguments.serializer(),
+            arguments,
+        )
+    }
+
+    val state: Flow<EditRssMediaSourceState> = mode.transformLatest { mode ->
+        when (mode) {
+            EditMediaSourceMode.Add -> {
+                val instanceId = Uuid.randomString()
+                emit(
+                    EditRssMediaSourceState(
+                        arguments = RssMediaSourceArguments.Default,
+                        editMediaSourceMode = mode,
+                        mediaSourceId = instanceId,
+                        onSave = { onSave(instanceId, it) },
+                        backgroundScope,
+                    ),
+                )
+            }
+
+            is EditMediaSourceMode.Edit -> {
+                val instanceId = mode.instanceId
+                emitAll(
+                    mediaSourceManager.instanceConfigFlow(instanceId).map { config ->
+                        EditRssMediaSourceState(
+                            arguments = config.deserializeArgumentsOrNull(RssMediaSourceArguments.serializer())
+                                ?: RssMediaSourceArguments.Default,
+                            editMediaSourceMode = mode,
+                            mediaSourceId = instanceId,
+                            onSave = { onSave(instanceId, it) },
+                            backgroundScope,
+                        )
+                    },
+                )
+            }
+        }
+    }
+}
+
+/**
+ * @see RssMediaSource
+ */
+@Stable
+class EditRssMediaSourceState(
+    val arguments: RssMediaSourceArguments,
+    val editMediaSourceMode: EditMediaSourceMode,
+    mediaSourceId: String,
+    private val onSave: suspend (RssMediaSourceArguments) -> Unit,
+    backgroundScope: CoroutineScope,
+) {
+    var mediaSourceId by mutableStateOf(mediaSourceId)
+
+    var displayName by mutableStateOf(arguments.name)
+    val displayNameIsError by derivedStateOf { displayName.isBlank() }
+
+    var iconUrl by mutableStateOf(arguments.iconUrl)
+    var searchUrl by mutableStateOf(arguments.searchUrl)
+
+    var dismissChanges by mutableStateOf(false)
+    val isChanged by derivedStateOf {
+        displayName != arguments.name || iconUrl != arguments.iconUrl || searchUrl != arguments.searchUrl
+    }
+
+    private val saveTasker = MonoTasker(backgroundScope)
+
+    fun save() {
+        saveTasker.launch {
+            onSave(
+                RssMediaSourceArguments(
+                    name = displayName,
+                    iconUrl = iconUrl,
+                    searchUrl = searchUrl,
+                    description = "",
+                ),
+            )
+        }
+    }
+}
+
+@Composable
+fun EditRssMediaSourcePage(
+    viewModel: EditRssMediaSourceViewModel,
+    modifier: Modifier = Modifier,
+) {
+    viewModel.state.collectAsStateWithLifecycle(null).value?.let {
+        EditRssMediaSourcePage(it, modifier)
+    }
+}
+
+@Composable
+fun EditRssMediaSourcePage(
+    state: EditRssMediaSourceState,
+    modifier: Modifier = Modifier,
+) {
+    val backHandler = LocalBackHandler.current
+    val confirmDiscardDialog = rememberConfirmDiscardChangeDialogState {
+        state.dismissChanges = false
+        backHandler.onBackPressed()
+    }
+    LaunchedEffect(true) {
+        snapshotFlow { state.isChanged }.collect {
+            state.dismissChanges = false
+        }
+    }
+
+    ConfirmDiscardChangeDialog(confirmDiscardDialog)
+
+    BackHandler(enabled = state.isChanged && !state.dismissChanges) {
+        confirmDiscardDialog.show()
+    }
+
+    Scaffold(
+        modifier.fillMaxSize().background(MaterialTheme.colorScheme.surface),
+        topBar = {
+            TopAppBar(
+                title = {
+                    when (state.editMediaSourceMode) {
+                        is EditMediaSourceMode.Edit -> Text(state.displayName)
+                        EditMediaSourceMode.Add -> Text("新建 RSS 数据源")
+                    }
+                },
+                navigationIcon = { TopAppBarGoBackButton() },
+                actions = {
+                    IconButton({ state.save() }) {
+                        Icon(Icons.Rounded.Save, contentDescription = "保存")
+                    }
+                },
+            )
+        },
+    ) { paddingValues ->
+        Surface {
+            Box(Modifier.fillMaxSize()) {
+                Column(
+                    Modifier.align(Alignment.TopCenter).fillMaxHeight().widthIn(max = BottomSheetDefaults.SheetMaxWidth)
+                        .padding(paddingValues),
+                ) {
+                    if (isInDebugMode()) {
+                        ListItem(
+                            headlineContent = { Text("ID") },
+                            supportingContent = { Text(state.mediaSourceId) },
+                        )
+                    }
+                    ListItem(
+                        headlineContent = { Text("名称") },
+                        supportingContent = {
+                            OutlinedTextField(
+                                state.displayName, { state.displayName = it.trim() },
+                                Modifier.fillMaxWidth().padding(top = 8.dp),
+                                placeholder = { Text("设置显示在列表中的名称") },
+                                isError = state.displayNameIsError,
+                                supportingText = { Text("必填") },
+                            )
+                        },
+                    )
+//            ListItem(
+//                headlineContent = { Text("备注") },
+//                supportingContent = {
+//                    OutlinedTextField(
+//                        state.description, { state.description = it },
+//                        placeholder = { Text("可留空") },
+//                    )
+//                },
+//            )
+                    ListItem(
+                        headlineContent = { Text("图标 URL") },
+                        supportingContent = {
+                            OutlinedTextField(
+                                state.iconUrl, { state.iconUrl = it },
+                                Modifier.fillMaxWidth().padding(top = 8.dp),
+                                supportingText = { Text("可留空") },
+                            )
+                        },
+                    )
+                    ListItem(
+                        headlineContent = { Text("查询网址") },
+                        supportingContent = {
+                            Column(Modifier.padding(top = 8.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                                ProvideTextStyle(MaterialTheme.typography.labelLarge) {
+                                    Text(
+                                        """
+                                    替换规则: 
+                                    {keyword} 替换为条目 (番剧) 名称
+                                    {page} 替换为页码, 如果不需要分页则忽略
+                                """.trimIndent(),
+                                    )
+                                }
+                                OutlinedTextField(
+                                    state.searchUrl, { state.searchUrl = it },
+                                    Modifier.fillMaxWidth().padding(top = 8.dp),
+                                    placeholder = { Text("例如  https://acg.rip/page/{page}.xml?term={keyword}") },
+                                    supportingText = { Text("必填") },
+                                )
+                            }
+                        },
+                    )
+
+                    HorizontalDivider(Modifier.padding(vertical = 16.dp))
+
+                    Button(
+                        onClick = { state.save() },
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(all = 16.dp),
+                        enabled = state.isChanged,
+                    ) {
+                        Text("保存")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/shared/src/commonMain/kotlin/ui/settings/tabs/media/source/MediaSourceGroup.kt
+++ b/app/shared/src/commonMain/kotlin/ui/settings/tabs/media/source/MediaSourceGroup.kt
@@ -33,7 +33,6 @@ import androidx.compose.material.icons.rounded.Reorder
 import androidx.compose.material.icons.rounded.Visibility
 import androidx.compose.material.icons.rounded.VisibilityOff
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.BasicAlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.DropdownMenu
@@ -45,10 +44,6 @@ import androidx.compose.material3.ProvideTextStyle
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.Immutable
-import androidx.compose.runtime.Stable
-import androidx.compose.runtime.State
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -61,85 +56,65 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.shareIn
-import kotlinx.coroutines.flow.stateIn
-import kotlinx.coroutines.withContext
-import me.him188.ani.app.data.source.media.fetch.MediaSourceManager
-import me.him188.ani.app.data.source.media.instance.MediaSourceInstance
-import me.him188.ani.app.tools.MonoTasker
+import me.him188.ani.app.data.source.media.source.RssMediaSource
+import me.him188.ani.app.navigation.LocalNavigator
 import me.him188.ani.app.ui.external.placeholder.placeholder
 import me.him188.ani.app.ui.foundation.ifThen
-import me.him188.ani.app.ui.settings.framework.ConnectionTestResult
-import me.him188.ani.app.ui.settings.framework.ConnectionTester
 import me.him188.ani.app.ui.settings.framework.ConnectionTesterResultIndicator
-import me.him188.ani.app.ui.settings.framework.DefaultConnectionTesterRunner
 import me.him188.ani.app.ui.settings.framework.components.SettingsScope
 import me.him188.ani.app.ui.settings.framework.components.TextButtonItem
 import me.him188.ani.app.ui.settings.framework.components.TextItem
-import me.him188.ani.app.ui.settings.rendering.MediaSourceIcon
 import me.him188.ani.app.ui.settings.framework.rememberSorterState
-import me.him188.ani.datasources.api.source.ConnectionStatus
-import me.him188.ani.datasources.api.source.FactoryId
-import me.him188.ani.datasources.api.source.MediaSourceConfig
-import me.him188.ani.datasources.api.source.MediaSourceFactory
-import me.him188.ani.datasources.api.source.MediaSourceInfo
-import me.him188.ani.datasources.api.source.parameter.MediaSourceParameters
+import me.him188.ani.app.ui.settings.rendering.MediaSourceIcon
 import me.him188.ani.datasources.api.source.parameter.isEmpty
-import me.him188.ani.utils.coroutines.childScope
 import org.burnoutcrew.reorderable.ReorderableItem
 import org.burnoutcrew.reorderable.detectReorder
 import org.burnoutcrew.reorderable.detectReorderAfterLongPress
 import org.burnoutcrew.reorderable.reorderable
-import kotlin.coroutines.CoroutineContext
-import kotlin.time.Duration.Companion.seconds
+
+internal val MediaSourcesUsingNewSettings = listOf(
+    RssMediaSource.FactoryId,
+)
 
 @Composable
 internal fun SettingsScope.MediaSourceGroup(
     state: MediaSourceGroupState,
     edit: EditMediaSourceState,
 ) {
-    var showAdd by remember { mutableStateOf(false) }
-    if (showAdd) {
+    val navigator = LocalNavigator.current
+    var showSelectTemplate by remember { mutableStateOf(false) }
+    if (showSelectTemplate) {
         // 选一个数据源来添加
         SelectMediaSourceTemplateDialog(
             templates = state.availableMediaSourceTemplates,
             onClick = {
-                if (it.parameters.list.isEmpty()) {
-                    // 没有参数, 直接添加
-                    edit.confirmEdit(edit.startAdding(it))
-                    showAdd = false
-                    return@SelectMediaSourceTemplateDialog
+                showSelectTemplate = false
+
+                // 一些数据源要用单独编辑页面
+                when {
+                    it.factoryId in MediaSourcesUsingNewSettings -> {
+                        navigator.navigateEditMediaSource(it.factoryId, null)
+                        return@SelectMediaSourceTemplateDialog
+                    }
+
+                    // 旧的数据源类型, 仍然使用旧的对话框形式添加
+                    it.parameters.list.isEmpty() -> {
+                        // 没有参数, 直接添加
+                        edit.confirmEdit(edit.startAdding(it))
+                        return@SelectMediaSourceTemplateDialog
+                    }
+
+                    else -> edit.startAdding(it)
                 }
-                edit.startAdding(it)
             },
-            onDismissRequest = { showAdd = false },
+            onDismissRequest = { showSelectTemplate = false },
         )
     }
 
     edit.editMediaSourceState?.let {
         // 准备添加这个数据源, 需要配置
-        BasicAlertDialog(
-            onDismissRequest = { edit.cancelEdit() },
-        ) {
-            EditMediaSourceDialog(
-                it,
-                onConfirm = {
-                    edit.confirmEdit(it)
-                    showAdd = false
-                },
-                onDismissRequest = {
-                    edit.cancelEdit()
-                    showAdd = false
-                },
-            )
-        }
+        // TODO: replace with a separate page
+        EditMediaSourceDialog(it, onDismissRequest = { edit.cancelEdit() })
     }
 
     val sorter = rememberSorterState<MediaSourcePresentation>(
@@ -165,7 +140,7 @@ internal fun SettingsScope.MediaSourceGroup(
                     IconButton(
                         {
                             edit.cancelEdit()
-                            showAdd = true
+                            showSelectTemplate = true
                         },
                     ) {
                         Icon(Icons.Rounded.Add, contentDescription = "添加数据源")
@@ -205,21 +180,25 @@ internal fun SettingsScope.MediaSourceGroup(
                     if (index != 0) {
                         HorizontalDividerItem()
                     }
+                    val startEditing = {
+                        if (item.factoryId in MediaSourcesUsingNewSettings) {
+                            navigator.navigateEditMediaSource(item.factoryId, item.instanceId)
+                        } else {
+                            edit.startEditing(item)
+                        }
+                    }
                     MediaSourceItem(
                         item,
                         Modifier.combinedClickable(
                             onClickLabel = "编辑",
                             onLongClick = { sorter.start(state.mediaSources) },
                             onLongClickLabel = "开始排序",
-                        ) {
-                            edit.startEditing(
-                                item,
-                            )
-                        },
+                            onClick = startEditing,
+                        ),
                     ) {
                         NormalMediaSourceItemAction(
                             item,
-                            onEdit = { edit.startEditing(item) },
+                            onEdit = startEditing,
                             onDelete = { edit.deleteMediaSource(item) },
                             onEnabledChange = { edit.toggleMediaSourceEnabled(item, it) },
                         )


### PR DESCRIPTION
以后每类型数据源有独立的 UI 配置. Part of #850

- UI 部分就是分别写一个 page/state, 统一由 `/settings/media-source/edit` 的 navigation route 分配. viewmodel 可以共用 (在未来增加 WEB 时用我现在的实现稍微改一下)
- 持久化部分增加了 `MediaSourceConfig.serializedArguments: JsonElement`, 每类型数据源可以自定义需要序列化的配置. 例如 RSS 源目前已经包含: 名称, icon, 搜索 URL. 下一个 PR 即将添加: 用来识别 size 的 tag 名称, seeders tag name, leechers tag name...
- 配置如何修改, 都是有数据源自己专门的 UI 页面修改. 没有任何通用修改方式.

考虑未来做导入/导出配置, 只需要序列化这个 `serializedArguments` 为字符串即可. 

### Breaking Change

3.9.0-alpha01 创建的 RSS 源的配置会丢失, 无所谓

### 历史遗留问题

Jellyfin, Emby, Ikaros 仍然需要使用旧版配置持久化方案. 旧版方案如下:
- 每个数据源 `MediaSourceFactory` 定义 `val parameters`, 数据源声明参数名称和默认值等参数, 由一个通用 UI 统一展示. 
- 这些配置会序列化到一个 `Map<String, String?>`, 也就是 `MediaSourceConfig.arguments`.

旧方案有重大设计缺陷. 各个数据源的配置实际上非常不一样, 例如 RSS 和自定义 web 数据源 (不论是 CSS selector based 还是 JS based), 除了 iconUrl 以外就没有一样的配置了. 使用 `val parameters = buildParameters {}` 方案, 可扩展性太低, 这个抽象反而增加了麻烦. 还有一个很重要的权限是, 该通用方案无法支持 RSS 数据源需要的测试 XML 解析, 和 WEB 数据源需要的测试 HTML 解析等含有复杂状态操作. 另外, 用该框架定义参数也没方便到哪里去. 

旧方案可以说是几乎没有优点, 因此弃用. 由于旧版本代码也实际上太多, 而且不能盲目删除 (Jellyfin 和 Ikaros 是作为稳定功能发布的),  重构起来也十分复杂 (需要至少在写两套 UI), 就先作为历史遗留保留在代码里面了. 为了避免编译器产生数百个 warning, 我也没给弃用的参数标记 deprecated. 从这个 PR 开始我们应当只使用新方案.


*P.S.: 我尝试过修改旧版对话框为单独页面, 但我失败了. 建议不要轻易尝试*