### PR TITLE
修复 desktop 端暂停播放时点击进度条无法跳转

### DIFF
--- a/app/shared/video-player/src/desktopMain/kotlin/ui/VideoPlayer.desktop.kt
+++ b/app/shared/video-player/src/desktopMain/kotlin/ui/VideoPlayer.desktop.kt
@@ -476,6 +476,7 @@ class VlcjVideoPlayerState(parentCoroutineContext: CoroutineContext) : PlayerSta
     }
 
     override fun seekTo(positionMillis: Long) {
+        currentPositionMillis.value = positionMillis
         player.controls().setTime(positionMillis)
     }
 


### PR DESCRIPTION
fix #909 