### PR TITLE
修复播放器弹出选倍速菜单后仍然会自动关闭

### DIFF
--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeVideo.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeVideo.kt
@@ -366,10 +366,19 @@ internal fun EpisodeVideoImpl(
                         PlayerControllerDefaults.SubtitleSwitcher(playerState.subtitleTracks)
 
                         val speed by playerState.playbackSpeed.collectAsStateWithLifecycle()
+                        val alwaysOnRequester = rememberAlwaysOnRequester(videoControllerState, "speedSwitcher")
                         SpeedSwitcher(
                             speed,
                             { playerState.setPlaybackSpeed(it) },
+                            onExpandedChanged = {
+                                if (it) {
+                                    alwaysOnRequester.request()
+                                } else {
+                                    alwaysOnRequester.cancelRequest()
+                                }
+                            },
                         )
+
                     }
                     PlayerControllerDefaults.FullscreenIcon(
                         expanded,

--- a/app/shared/src/desktopTest/kotlin/ui/subject/episode/EpisodeVideoControllerTest.kt
+++ b/app/shared/src/desktopTest/kotlin/ui/subject/episode/EpisodeVideoControllerTest.kt
@@ -49,6 +49,8 @@ import me.him188.ani.app.videoplayer.ui.progress.TAG_MEDIA_PROGRESS_INDICATOR_TE
 import me.him188.ani.app.videoplayer.ui.progress.TAG_PROGRESS_SLIDER
 import me.him188.ani.app.videoplayer.ui.progress.TAG_PROGRESS_SLIDER_PREVIEW_POPUP
 import me.him188.ani.app.videoplayer.ui.progress.TAG_SELECT_EPISODE_ICON_BUTTON
+import me.him188.ani.app.videoplayer.ui.progress.TAG_SPEED_SWITCHER_DROPDOWN_MENU
+import me.him188.ani.app.videoplayer.ui.progress.TAG_SPEED_SWITCHER_TEXT_BUTTON
 import me.him188.ani.app.videoplayer.ui.state.DummyPlayerState
 import me.him188.ani.app.videoplayer.ui.top.PlayerTopBar
 import me.him188.ani.danmaku.api.Danmaku
@@ -668,6 +670,17 @@ class EpisodeVideoControllerTest {
             waitForSideSheetClose = { waitUntil { onNodeWithTag(TAG_EPISODE_SELECTOR_SHEET).doesNotExist() } },
         )
     }
+
+    @Test
+    fun `touch - hover to always on - speed switcher`() = runAniComposeUiTest {
+        // 并非 side sheet
+        testSideSheetRequestAlwaysOn(
+            gestureFamily = GestureFamily.TOUCH,
+            openSideSheet = { onNodeWithTag(TAG_SPEED_SWITCHER_TEXT_BUTTON).performClick() },
+            waitForSideSheetOpen = { waitUntil { onNodeWithTag(TAG_SPEED_SWITCHER_DROPDOWN_MENU).exists() } },
+            waitForSideSheetClose = { waitUntil { onNodeWithTag(TAG_SPEED_SWITCHER_DROPDOWN_MENU).doesNotExist() } },
+        )
+    }
     ///////////////////////////////////////////////////////////////////////////
     // mouse
     ///////////////////////////////////////////////////////////////////////////
@@ -818,6 +831,11 @@ class EpisodeVideoControllerTest {
             root.performTouchInput {
                 click(center)
             }
+            // 目前的 controller mouseHoverForController 依赖 Move 事件, 但 compose 似乎有点问题
+            // 所以额外广播一个事件
+            root.performTouchInput {
+                swipe(center, center - Offset(1f, 1f))
+            }
         }
         runOnIdle {
             waitForSideSheetClose()
@@ -864,6 +882,17 @@ class EpisodeVideoControllerTest {
         )
     }
 
+    @Test
+    fun `mouse - hover to always on - speed switcher`() = runAniComposeUiTest {
+        // 并非 side sheet
+        testSideSheetRequestAlwaysOn(
+            gestureFamily = GestureFamily.MOUSE,
+            openSideSheet = { onNodeWithTag(TAG_SPEED_SWITCHER_TEXT_BUTTON).performClick() },
+            waitForSideSheetOpen = { waitUntil { onNodeWithTag(TAG_SPEED_SWITCHER_DROPDOWN_MENU).exists() } },
+            waitForSideSheetClose = { waitUntil { onNodeWithTag(TAG_SPEED_SWITCHER_DROPDOWN_MENU).doesNotExist() } },
+        )
+    }
+    
     ///////////////////////////////////////////////////////////////////////////
     // MOUSE 模式下单击鼠标
     ///////////////////////////////////////////////////////////////////////////

--- a/app/shared/video-player/src/commonMain/kotlin/ui/progress/PlayerControllerBar.kt
+++ b/app/shared/video-player/src/commonMain/kotlin/ui/progress/PlayerControllerBar.kt
@@ -95,6 +95,8 @@ import me.him188.ani.app.videoplayer.ui.top.needWorkaroundForFocusManager
 import kotlin.math.roundToInt
 
 const val TAG_SELECT_EPISODE_ICON_BUTTON = "SelectEpisodeIconButton"
+const val TAG_SPEED_SWITCHER_TEXT_BUTTON = "SpeedSwitcherTextButton"
+const val TAG_SPEED_SWITCHER_DROPDOWN_MENU = "SpeedSwitcherDropdownMenu"
 
 @Stable
 object PlayerControllerDefaults {
@@ -471,10 +473,11 @@ object PlayerControllerDefaults {
             optionsProvider = optionsProvider,
             renderValue = { Text(remember(it) { "${it}x" }) },
             renderValueExposed = { Text(remember(it) { if (it == 1.0f) "倍速" else """${it}x""" }) },
-            modifier,
             properties = PlatformPopupProperties(
                 clippingEnabled = false,
             ),
+            textButtonTestTag = TAG_SPEED_SWITCHER_TEXT_BUTTON,
+            dropdownMenuTestTag = TAG_SPEED_SWITCHER_DROPDOWN_MENU,
             onExpandedChanged = onExpandedChanged,
         )
     }
@@ -492,6 +495,8 @@ object PlayerControllerDefaults {
         modifier: Modifier = Modifier,
         enabled: Boolean = true,
         properties: PopupProperties = PopupProperties(),
+        textButtonTestTag: String = "textButton",
+        dropdownMenuTestTag: String = "dropDownMenu",
         onExpandedChanged: (expanded: Boolean) -> Unit = {},
     ) {
         Box(modifier, contentAlignment = Alignment.Center) {
@@ -507,6 +512,7 @@ object PlayerControllerDefaults {
                     contentColor = LocalContentColor.current,
                 ),
                 enabled = enabled,
+                modifier = Modifier.testTag(textButtonTestTag),
             ) {
                 renderValueExposed(value)
             }
@@ -515,6 +521,7 @@ object PlayerControllerDefaults {
                 expanded = expanded,
                 onDismissRequest = { expanded = false },
                 properties = properties,
+                modifier = Modifier.testTag(dropdownMenuTestTag),
             ) {
                 val options = remember(optionsProvider) { optionsProvider() }
                 for (option in options) {

--- a/app/shared/video-player/src/commonMain/kotlin/ui/progress/PlayerControllerBar.kt
+++ b/app/shared/video-player/src/commonMain/kotlin/ui/progress/PlayerControllerBar.kt
@@ -473,6 +473,7 @@ object PlayerControllerDefaults {
             optionsProvider = optionsProvider,
             renderValue = { Text(remember(it) { "${it}x" }) },
             renderValueExposed = { Text(remember(it) { if (it == 1.0f) "倍速" else """${it}x""" }) },
+            modifier,
             properties = PlatformPopupProperties(
                 clippingEnabled = false,
             ),

--- a/app/shared/video-player/src/commonMain/kotlin/ui/progress/PlayerControllerBar.kt
+++ b/app/shared/video-player/src/commonMain/kotlin/ui/progress/PlayerControllerBar.kt
@@ -463,6 +463,7 @@ object PlayerControllerDefaults {
         onValueChange: (Float) -> Unit,
         modifier: Modifier = Modifier,
         optionsProvider: () -> List<Float> = { listOf(0.5f, 0.75f, 1f, 1.25f, 1.5f, 1.75f, 2f, 3f) },
+        onExpandedChanged: (expanded: Boolean) -> Unit = {},
     ) {
         return OptionsSwitcher(
             value = value,
@@ -474,6 +475,7 @@ object PlayerControllerDefaults {
             properties = PlatformPopupProperties(
                 clippingEnabled = false,
             ),
+            onExpandedChanged = onExpandedChanged,
         )
     }
 
@@ -490,9 +492,15 @@ object PlayerControllerDefaults {
         modifier: Modifier = Modifier,
         enabled: Boolean = true,
         properties: PopupProperties = PopupProperties(),
+        onExpandedChanged: (expanded: Boolean) -> Unit = {},
     ) {
         Box(modifier, contentAlignment = Alignment.Center) {
             var expanded by rememberSaveable { mutableStateOf(false) }
+            LaunchedEffect(true) {
+                snapshotFlow { expanded }.collect {
+                    onExpandedChanged(expanded)
+                }
+            }
             TextButton(
                 { expanded = true },
                 colors = ButtonDefaults.textButtonColors(


### PR DESCRIPTION
fix #891 
有个小问题是：弹出倍速菜单后点击播放器内的区域，虽然可以隐藏倍速菜单，但是会导致desktop端播放状态改变，安卓controller visibility 改变，有办法 consume 这个 click 吗