### PR TITLE
检测计费网络状态来限制 BT 上传

### DIFF
--- a/app/android/src/main/AndroidManifest.xml
+++ b/app/android/src/main/AndroidManifest.xml
@@ -22,6 +22,7 @@
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <!--    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"-->
     <!--            tools:ignore="ScopedStorage" />-->
 

--- a/app/android/src/main/kotlin/AndroidModules.kt
+++ b/app/android/src/main/kotlin/AndroidModules.kt
@@ -25,13 +25,13 @@ import me.him188.ani.app.domain.media.resolver.HttpStreamingVideoSourceResolver
 import me.him188.ani.app.domain.media.resolver.LocalFileVideoSourceResolver
 import me.him188.ani.app.domain.media.resolver.TorrentVideoSourceResolver
 import me.him188.ani.app.domain.media.resolver.VideoSourceResolver
+import me.him188.ani.app.domain.torrent.DefaultTorrentManager
+import me.him188.ani.app.domain.torrent.TorrentManager
 import me.him188.ani.app.navigation.BrowserNavigator
 import me.him188.ani.app.platform.AndroidPermissionManager
 import me.him188.ani.app.platform.PermissionManager
 import me.him188.ani.app.platform.notification.AndroidNotifManager
 import me.him188.ani.app.platform.notification.NotifManager
-import me.him188.ani.app.domain.torrent.DefaultTorrentManager
-import me.him188.ani.app.domain.torrent.TorrentManager
 import me.him188.ani.app.tools.update.AndroidUpdateInstaller
 import me.him188.ani.app.tools.update.UpdateInstaller
 import me.him188.ani.app.videoplayer.ExoPlayerStateFactory
@@ -150,6 +150,7 @@ fun getAndroidModules(
 
         DefaultTorrentManager.create(
             coroutineScope.coroutineContext,
+            get(),
             get(),
             baseSaveDir = { Path(cacheDir).inSystem },
         )

--- a/app/android/src/main/kotlin/activity/MainActivity.kt
+++ b/app/android/src/main/kotlin/activity/MainActivity.kt
@@ -31,6 +31,7 @@ import me.him188.ani.app.domain.session.SessionManager
 import me.him188.ani.app.navigation.AniNavigator
 import me.him188.ani.app.navigation.NavRoutes
 import me.him188.ani.app.platform.AppStartupTasks
+import me.him188.ani.app.platform.MeteredNetworkDetector
 import me.him188.ani.app.platform.PlatformWindow
 import me.him188.ani.app.platform.notification.AndroidNotifManager
 import me.him188.ani.app.platform.notification.AndroidNotifManager.Companion.EXTRA_REQUEST_CODE
@@ -51,6 +52,8 @@ import org.koin.mp.KoinPlatformTools
 
 class MainActivity : AniComponentActivity() {
     private val sessionManager: SessionManager by inject()
+    private val meteredNetworkDetector: MeteredNetworkDetector by inject()
+    
     private val logger = logger(MainActivity::class)
 
     private val aniNavigator = AniNavigator()

--- a/app/desktop/src/main/kotlin/AniDesktop.kt
+++ b/app/desktop/src/main/kotlin/AniDesktop.kt
@@ -202,6 +202,7 @@ object AniDesktop {
                         DefaultTorrentManager.create(
                             coroutineScope.coroutineContext,
                             get(),
+                            get(),
                             baseSaveDir = {
                                 val saveDir = runBlocking {
                                     get<SettingsRepository>().mediaCacheSettings.flow.first().saveDir

--- a/app/shared/AndroidManifest.xml
+++ b/app/shared/AndroidManifest.xml
@@ -22,4 +22,5 @@
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
 </manifest>

--- a/app/shared/app-data/src/commonMain/kotlin/data/models/preference/AnitorrentConfig.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/models/preference/AnitorrentConfig.kt
@@ -1,9 +1,19 @@
+/*
+ * Copyright (C) 2024 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
 package me.him188.ani.app.data.models.preference
 
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
 import me.him188.ani.datasources.api.topic.FileSize
 import me.him188.ani.datasources.api.topic.FileSize.Companion.megaBytes
+import me.him188.ani.utils.platform.Platform
 
 @Serializable
 data class AnitorrentConfig(
@@ -32,4 +42,8 @@ data class AnitorrentConfig(
 
         val Default = AnitorrentConfig()
     }
+}
+
+fun Platform.supportsLimitUploadOnMeteredNetwork(): Boolean {
+    return this is Platform.Android || this is Platform.Windows
 }

--- a/app/shared/app-data/src/commonMain/kotlin/data/models/preference/AnitorrentConfig.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/models/preference/AnitorrentConfig.kt
@@ -19,6 +19,12 @@ data class AnitorrentConfig(
      * 种子分享率限制.
      */
     val shareRatioLimit: Double = 1.1,
+    /**
+     * 在计费网络限制上传速度为 1 KB/s
+     * * Android 移动流量
+     * * Windows 计费 Wi-Fi
+     */
+    val limitUploadOnMeteredNetwork: Boolean = false,
     @Transient private val _placeholder: Int = 0,
 ) {
     companion object {

--- a/app/shared/app-data/src/commonMain/kotlin/data/models/preference/AnitorrentConfig.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/models/preference/AnitorrentConfig.kt
@@ -24,7 +24,7 @@ data class AnitorrentConfig(
      * * Android 移动流量
      * * Windows 计费 Wi-Fi
      */
-    val limitUploadOnMeteredNetwork: Boolean = false,
+    val limitUploadOnMeteredNetwork: Boolean = true,
     @Transient private val _placeholder: Int = 0,
 ) {
     companion object {

--- a/app/shared/app-platform/src/androidMain/kotlin/platform/MeteredNetworkDetector.android.kt
+++ b/app/shared/app-platform/src/androidMain/kotlin/platform/MeteredNetworkDetector.android.kt
@@ -20,14 +20,12 @@ import kotlinx.coroutines.flow.MutableStateFlow
 
 @SuppressLint("MissingPermission")
 private class AndroidMeteredNetworkDetector(
-    private val context: Context
+    context: Context
 ) : MeteredNetworkDetector {
+    private val connectivityManager = context.getSystemService(ConnectivityManager::class.java)
+
     private val flow = MutableStateFlow(getCurrentIsMetered())
     override val isMeteredNetworkFlow: Flow<Boolean> get() = flow
-
-    private val connectivityManager by lazy {
-        context.getSystemService(ConnectivityManager::class.java)
-    }
 
     // Create a NetworkCallback to detect network changes
     private val networkCallback = object : ConnectivityManager.NetworkCallback() {

--- a/app/shared/app-platform/src/androidMain/kotlin/platform/MeteredNetworkDetector.android.kt
+++ b/app/shared/app-platform/src/androidMain/kotlin/platform/MeteredNetworkDetector.android.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2024 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.platform
+
+import android.content.BroadcastReceiver
+import android.content.Intent
+import android.content.IntentFilter
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+
+
+private class AndroidMeteredNetworkDetector(
+    private val context: Context
+) : BroadcastReceiver(), MeteredNetworkDetector {
+    private val flow = MutableSharedFlow<Boolean>(extraBufferCapacity = 1)
+    override val isMeteredNetworkFlow: Flow<Boolean> = flow
+    
+    private val connectivityManager by lazy { 
+        context.getSystemService(ConnectivityManager::class.java) 
+    }
+    
+    init {
+        context.registerReceiver(this, IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION))
+        // emit first value
+        flow.tryEmit(getCurrentIsMetered())
+    }
+
+    override fun onReceive(context: Context?, intent: Intent?) {
+        flow.tryEmit(getCurrentIsMetered())
+    }
+    
+    private fun getCurrentIsMetered(): Boolean {
+        val activeNetwork = connectivityManager.activeNetwork ?: return false
+        val activeNetworkCapabilities = connectivityManager.getNetworkCapabilities(activeNetwork) ?: return false
+        
+        return !activeNetworkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_METERED)
+    }
+
+    override fun dispose() {
+        context.unregisterReceiver(this)
+    }
+    
+}
+
+actual fun createMeteredNetworkDetector(context: Context): MeteredNetworkDetector {
+    return AndroidMeteredNetworkDetector(context)
+}

--- a/app/shared/app-platform/src/androidMain/kotlin/platform/MeteredNetworkDetector.android.kt
+++ b/app/shared/app-platform/src/androidMain/kotlin/platform/MeteredNetworkDetector.android.kt
@@ -22,9 +22,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 private class AndroidMeteredNetworkDetector(
     private val context: Context
 ) : MeteredNetworkDetector {
-
-    private val flow = MutableStateFlow(false)
-    override val isMeteredNetworkFlow: Flow<Boolean> = flow
+    private val flow = MutableStateFlow(getCurrentIsMetered())
+    override val isMeteredNetworkFlow: Flow<Boolean> get() = flow
 
     private val connectivityManager by lazy {
         context.getSystemService(ConnectivityManager::class.java)

--- a/app/shared/app-platform/src/androidMain/kotlin/platform/MeteredNetworkDetector.android.kt
+++ b/app/shared/app-platform/src/androidMain/kotlin/platform/MeteredNetworkDetector.android.kt
@@ -15,7 +15,7 @@ import android.net.Network
 import android.net.NetworkCapabilities
 import android.net.NetworkRequest
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 
 
 @SuppressLint("MissingPermission")
@@ -23,7 +23,7 @@ private class AndroidMeteredNetworkDetector(
     private val context: Context
 ) : MeteredNetworkDetector {
 
-    private val flow = MutableSharedFlow<Boolean>(extraBufferCapacity = 1)
+    private val flow = MutableStateFlow(false)
     override val isMeteredNetworkFlow: Flow<Boolean> = flow
 
     private val connectivityManager by lazy {

--- a/app/shared/app-platform/src/commonMain/kotlin/platform/MeteredNetworkDetector.kt
+++ b/app/shared/app-platform/src/commonMain/kotlin/platform/MeteredNetworkDetector.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2024 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.platform
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Platform-dependent network type detector.
+ * 
+ * Use [createMeteredNetworkDetector] to create instance.
+ */
+interface MeteredNetworkDetector {
+    val isMeteredNetworkFlow: Flow<Boolean>
+
+    /**
+     * Dispose listeners or callbacks which may be created at initializing detector.
+     */
+    fun dispose() { }
+}
+
+
+expect fun createMeteredNetworkDetector(context: ContextMP): MeteredNetworkDetector

--- a/app/shared/app-platform/src/commonMain/kotlin/platform/MeteredNetworkDetector.kt
+++ b/app/shared/app-platform/src/commonMain/kotlin/platform/MeteredNetworkDetector.kt
@@ -10,10 +10,11 @@
 package me.him188.ani.app.platform
 
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
 
 /**
  * Platform-dependent network type detector.
- * 
+ *
  * Use [createMeteredNetworkDetector] to create instance.
  */
 interface MeteredNetworkDetector {
@@ -23,6 +24,13 @@ interface MeteredNetworkDetector {
      * Dispose listeners or callbacks which may be created at initializing detector.
      */
     fun dispose()
+}
+
+object NoopMeteredNetworkDetector : MeteredNetworkDetector {
+    override val isMeteredNetworkFlow: Flow<Boolean> = flowOf(false)
+
+    override fun dispose() {
+    }
 }
 
 

--- a/app/shared/app-platform/src/commonMain/kotlin/platform/MeteredNetworkDetector.kt
+++ b/app/shared/app-platform/src/commonMain/kotlin/platform/MeteredNetworkDetector.kt
@@ -22,7 +22,7 @@ interface MeteredNetworkDetector {
     /**
      * Dispose listeners or callbacks which may be created at initializing detector.
      */
-    fun dispose() { }
+    fun dispose()
 }
 
 

--- a/app/shared/app-platform/src/desktopMain/kotlin/platform/MeteredNetworkDetector.desktop.kt
+++ b/app/shared/app-platform/src/desktopMain/kotlin/platform/MeteredNetworkDetector.desktop.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2024 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.platform
+
+import com.sun.jna.platform.win32.COM.COMException
+import com.sun.jna.platform.win32.COM.COMUtils
+import com.sun.jna.platform.win32.COM.Unknown
+import com.sun.jna.platform.win32.Guid
+import com.sun.jna.platform.win32.Ole32
+import com.sun.jna.platform.win32.WTypes
+import com.sun.jna.platform.win32.WinNT.HRESULT
+import com.sun.jna.ptr.IntByReference
+import com.sun.jna.ptr.PointerByReference
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import me.him188.ani.utils.logging.logger
+import me.him188.ani.utils.logging.warn
+import me.him188.ani.utils.platform.Platform
+import me.him188.ani.utils.platform.currentPlatformDesktop
+
+
+private class WindowsMeteredNetworkDetector : MeteredNetworkDetector {
+    private val logger = logger<MeteredNetworkDetector>()
+    
+    private val flow = flow {
+        while (true) {
+            emit(getIsMetered())
+            kotlinx.coroutines.delay(3000)
+        }
+    }
+    override val isMeteredNetworkFlow: Flow<Boolean> = flow
+    
+    private fun getIsMetered(): Boolean {
+        var networkConnectionCost: INetworkConnectionCost? = null
+
+        try {
+            val coInitializeHResult = Ole32.INSTANCE.CoInitializeEx(null, Ole32.COINIT_MULTITHREADED)
+            COMUtils.checkRC(coInitializeHResult)
+
+            val pNetworkCostManager = PointerByReference()
+            val coCreateInstanceHResult = Ole32.INSTANCE.CoCreateInstance(
+                CLSID_NetworkListManager,
+                null,
+                WTypes.CLSCTX_ALL,
+                IID_INetworkCostManager,
+                pNetworkCostManager,
+            )
+            COMUtils.checkRC(coCreateInstanceHResult)
+            
+            networkConnectionCost = INetworkConnectionCost(pNetworkCostManager)
+            val pCost = IntByReference()
+            
+            val getCostResult = networkConnectionCost.GetCost(pCost)
+            COMUtils.checkRC(getCostResult)
+            
+            return (pCost.value and NLM_CONNECTION_COST_FIXED) != 0
+        } catch (ex: COMException) {
+            logger.warn(ex) { "Failed to get network status." }
+            return false
+        } finally {
+            networkConnectionCost?.Release()
+            Ole32.INSTANCE.CoUninitialize()
+        }
+    }
+    
+    private class INetworkConnectionCost(pointer: PointerByReference) : Unknown(pointer.value) {
+        @Suppress("FunctionName")
+        fun GetCost(cost: IntByReference): HRESULT {
+            return _invokeNativeObject(3, arrayOf(pointer, cost, null), HRESULT::class.java) as HRESULT
+        }
+    }
+    
+    @Suppress("unused")
+    companion object {
+        private val CLSID_NetworkListManager = Guid.CLSID("{DCB00C01-570F-4A9B-8D69-199FDBA5723B}")
+        private val IID_INetworkCostManager = Guid.IID("{DCB00008-570F-4A9B-8D69-199FDBA5723B}")
+        
+        private const val NLM_CONNECTION_COST_UNKNOWN = 0
+        private const val NLM_CONNECTION_COST_UNRESTRICTED = 0x1
+        private const val NLM_CONNECTION_COST_FIXED = 0x2
+        private const val NLM_CONNECTION_COST_VARIABLE = 0x4
+        private const val NLM_CONNECTION_COST_OVERDATALIMIT = 0x10000
+        private const val NLM_CONNECTION_COST_CONGESTED = 0x20000
+        private const val NLM_CONNECTION_COST_ROAMING = 0x40000
+        private const val NLM_CONNECTION_COST_APPROACHINGDATALIMIT = 0x80000
+    }
+}
+
+actual fun createMeteredNetworkDetector(context: Context): MeteredNetworkDetector {
+    return when (currentPlatformDesktop()) {
+        is Platform.Windows -> WindowsMeteredNetworkDetector()
+        else -> object : MeteredNetworkDetector {
+            override val isMeteredNetworkFlow: Flow<Boolean> = flowOf(false)
+        }
+    }
+}
+

--- a/app/shared/app-platform/src/desktopMain/kotlin/platform/MeteredNetworkDetector.desktop.kt
+++ b/app/shared/app-platform/src/desktopMain/kotlin/platform/MeteredNetworkDetector.desktop.kt
@@ -20,7 +20,6 @@ import com.sun.jna.ptr.IntByReference
 import com.sun.jna.ptr.PointerByReference
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.flowOf
 import me.him188.ani.utils.logging.logger
 import me.him188.ani.utils.logging.warn
 import me.him188.ani.utils.platform.Platform
@@ -72,9 +71,9 @@ private class WindowsMeteredNetworkDetector : MeteredNetworkDetector {
     }
 
     override fun dispose() {
-        
+
     }
-    
+
     private class INetworkCostManager(pointer: PointerByReference) : Unknown(pointer.value) {
         @Suppress("FunctionName")
         fun GetCost(cost: IntByReference): HRESULT {
@@ -101,16 +100,8 @@ private class WindowsMeteredNetworkDetector : MeteredNetworkDetector {
 actual fun createMeteredNetworkDetector(context: Context): MeteredNetworkDetector {
     return when (currentPlatformDesktop()) {
         is Platform.Windows -> WindowsMeteredNetworkDetector()
-        is Platform.MacOS -> object : MeteredNetworkDetector {
-            // macos API 要用 swift 才能实现
-            override val isMeteredNetworkFlow: Flow<Boolean> = flowOf(false)
-            override fun dispose() { }
-        }
-
-        else -> object : MeteredNetworkDetector {
-            override val isMeteredNetworkFlow: Flow<Boolean> = flowOf(false)
-            override fun dispose() { }
-        }
+        is Platform.MacOS -> NoopMeteredNetworkDetector // macos API 要用 swift 才能实现
+        is Platform.Linux -> NoopMeteredNetworkDetector
     }
 }
 

--- a/app/shared/app-platform/src/iosMain/kotlin/platform/MeteredNetworkDetector.ios.kt
+++ b/app/shared/app-platform/src/iosMain/kotlin/platform/MeteredNetworkDetector.ios.kt
@@ -7,6 +7,8 @@
  * https://github.com/open-ani/ani/blob/main/LICENSE
  */
 
+package me.him188.ani.app.platform
+
 actual fun createMeteredNetworkDetector(context: Context): MeteredNetworkDetector {
     return NoopMeteredNetworkDetector
 }

--- a/app/shared/app-platform/src/iosMain/kotlin/platform/MeteredNetworkDetector.ios.kt
+++ b/app/shared/app-platform/src/iosMain/kotlin/platform/MeteredNetworkDetector.ios.kt
@@ -1,0 +1,15 @@
+/*
+ * Copyright (C) 2024 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+actual fun createMeteredNetworkDetector(context: Context): MeteredNetworkDetector {
+    return object : MeteredNetworkDetector {
+        override val isMeteredNetworkFlow: Flow<Boolean> = flowOf(false)
+        override fun dispose() { }
+    }
+}

--- a/app/shared/app-platform/src/iosMain/kotlin/platform/MeteredNetworkDetector.ios.kt
+++ b/app/shared/app-platform/src/iosMain/kotlin/platform/MeteredNetworkDetector.ios.kt
@@ -8,8 +8,5 @@
  */
 
 actual fun createMeteredNetworkDetector(context: Context): MeteredNetworkDetector {
-    return object : MeteredNetworkDetector {
-        override val isMeteredNetworkFlow: Flow<Boolean> = flowOf(false)
-        override fun dispose() { }
-    }
+    return NoopMeteredNetworkDetector
 }

--- a/app/shared/application/src/commonMain/kotlin/platform/CommonKoinModule.kt
+++ b/app/shared/application/src/commonMain/kotlin/platform/CommonKoinModule.kt
@@ -15,7 +15,6 @@ import io.ktor.client.statement.bodyAsText
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
@@ -262,6 +261,8 @@ fun KoinApplication.getCommonKoinModule(getContext: () -> Context, coroutineScop
     CacheProgressStateFactoryManager.register(TorrentVideoData::class) { videoData, state ->
         TorrentMediaCacheProgressState(videoData.pieces) { state.value }
     }
+    
+    single<MeteredNetworkDetector> { createMeteredNetworkDetector(getContext()) }
 }
 
 

--- a/app/shared/application/src/commonMain/kotlin/platform/CommonKoinModule.kt
+++ b/app/shared/application/src/commonMain/kotlin/platform/CommonKoinModule.kt
@@ -93,6 +93,7 @@ import me.him188.ani.app.videoplayer.ui.state.CacheProgressStateFactoryManager
 import me.him188.ani.datasources.bangumi.BangumiClient
 import me.him188.ani.datasources.bangumi.DelegateBangumiClient
 import me.him188.ani.datasources.bangumi.createBangumiClient
+import me.him188.ani.utils.coroutines.IO_
 import me.him188.ani.utils.coroutines.childScope
 import me.him188.ani.utils.coroutines.childScopeContext
 import me.him188.ani.utils.coroutines.onReplacement
@@ -171,7 +172,7 @@ fun KoinApplication.getCommonKoinModule(getContext: () -> Context, coroutineScop
         getContext().createDatabaseBuilder()
             .fallbackToDestructiveMigrationOnDowngrade(true)
             .setDriver(BundledSQLiteDriver())
-            .setQueryCoroutineContext(Dispatchers.IO)
+            .setQueryCoroutineContext(Dispatchers.IO_)
             .build()
     }
 

--- a/app/shared/application/src/iosMain/kotlin/ios/AniIos.kt
+++ b/app/shared/application/src/iosMain/kotlin/ios/AniIos.kt
@@ -188,6 +188,7 @@ fun getIosModules(
         DefaultTorrentManager.create(
             coroutineScope.coroutineContext,
             get(),
+            meteredNetworkDetector = get(),
             baseSaveDir = { defaultTorrentCacheDir },
         )
     }

--- a/app/shared/src/commonMain/kotlin/ui/foundation/Previewing.kt
+++ b/app/shared/src/commonMain/kotlin/ui/foundation/Previewing.kt
@@ -90,6 +90,7 @@ fun ProvideCompositionLocalsForPreview(
                         DefaultTorrentManager.create(
                             coroutineScope.coroutineContext,
                             get(),
+                            get(),
                             baseSaveDir = { Path("preview-cache").inSystem },
                         )
                     }

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/tabs/DebugTab.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/tabs/DebugTab.kt
@@ -22,7 +22,7 @@ import me.him188.ani.app.ui.settings.SettingsTab
 import me.him188.ani.app.ui.settings.framework.SettingsState
 import me.him188.ani.app.ui.settings.framework.components.SwitchItem
 import me.him188.ani.app.ui.settings.framework.components.TextItem
-import org.koin.core.context.GlobalContext
+import org.koin.mp.KoinPlatform
 
 @Composable
 fun DebugTab(
@@ -66,7 +66,7 @@ fun DebugTab(
                 Text("supportsLimitUploadOnMeteredNetwork: $networkDetector")
             }
             TextItem {
-                val networkDetector = GlobalContext.get().get<MeteredNetworkDetector>()
+                val networkDetector = KoinPlatform.getKoin().get<MeteredNetworkDetector>()
                 val isMetered by networkDetector.isMeteredNetworkFlow.collectAsStateWithLifecycle(false)
                 Text("isMetered: $isMetered")
             }

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/tabs/DebugTab.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/tabs/DebugTab.kt
@@ -1,13 +1,28 @@
+/*
+ * Copyright (C) 2024 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
 package me.him188.ani.app.ui.settings.tabs
 
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import me.him188.ani.app.data.models.preference.DebugSettings
+import me.him188.ani.app.data.models.preference.supportsLimitUploadOnMeteredNetwork
+import me.him188.ani.app.platform.MeteredNetworkDetector
+import me.him188.ani.app.ui.foundation.LocalPlatform
 import me.him188.ani.app.ui.settings.SettingsTab
 import me.him188.ani.app.ui.settings.framework.SettingsState
 import me.him188.ani.app.ui.settings.framework.components.SwitchItem
+import me.him188.ani.app.ui.settings.framework.components.TextItem
+import org.koin.core.context.GlobalContext
 
 @Composable
 fun DebugTab(
@@ -44,6 +59,17 @@ fun DebugTab(
                 title = { Text("显示所有剧集") },
                 description = { Text("显示所有剧集，包括SP、OP、ED等，目前仅部分在线源支持，请谨慎启用") },
             )
+        }
+        Group(title = { Text("计费网络信息") }, useThinHeader = true) {
+            TextItem {
+                val networkDetector = LocalPlatform.current.supportsLimitUploadOnMeteredNetwork()
+                Text("supportsLimitUploadOnMeteredNetwork: $networkDetector")
+            }
+            TextItem {
+                val networkDetector = GlobalContext.get().get<MeteredNetworkDetector>()
+                val isMetered by networkDetector.isMeteredNetworkFlow.collectAsStateWithLifecycle(false)
+                Text("isMetered: $isMetered")
+            }
         }
     }
 }

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/tabs/media/TorrentEngineGroup.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/tabs/media/TorrentEngineGroup.kt
@@ -1,3 +1,12 @@
+/*
+ * Copyright (C) 2024 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
 package me.him188.ani.app.ui.settings.tabs.media
 
 import androidx.compose.foundation.layout.RowScope
@@ -14,7 +23,9 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import me.him188.ani.app.data.models.preference.AnitorrentConfig
+import me.him188.ani.app.data.models.preference.supportsLimitUploadOnMeteredNetwork
 import me.him188.ani.app.navigation.LocalNavigator
+import me.him188.ani.app.ui.foundation.LocalPlatform
 import me.him188.ani.app.ui.settings.framework.SettingsState
 import me.him188.ani.app.ui.settings.framework.components.SettingsScope
 import me.him188.ani.app.ui.settings.framework.components.SliderItem
@@ -87,12 +98,14 @@ internal fun SettingsScope.TorrentEngineGroup(
                 },
                 title = { Text("上传速度限制") },
             )
-            SwitchItem(
-                checked = torrentSettings.limitUploadOnMeteredNetwork,
-                onCheckedChange = { torrentSettingsState.update(torrentSettings.copy(limitUploadOnMeteredNetwork = it)) },
-                title = { Text("计费网络限制上传") },
-                description = { Text("在计费网络环境下限制上传速度为 1 KB/s") }
-            )
+            if (LocalPlatform.current.supportsLimitUploadOnMeteredNetwork()) {
+                SwitchItem(
+                    checked = torrentSettings.limitUploadOnMeteredNetwork,
+                    onCheckedChange = { torrentSettingsState.update(torrentSettings.copy(limitUploadOnMeteredNetwork = it)) },
+                    title = { Text("计费网络限制上传") },
+                    description = { Text("在计费网络环境下限制上传速度为 1 KB/s") },
+                )
+            }
         }
         val navigator by rememberUpdatedState(LocalNavigator.current)
         TextItem(

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/tabs/media/TorrentEngineGroup.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/tabs/media/TorrentEngineGroup.kt
@@ -18,6 +18,7 @@ import me.him188.ani.app.navigation.LocalNavigator
 import me.him188.ani.app.ui.settings.framework.SettingsState
 import me.him188.ani.app.ui.settings.framework.components.SettingsScope
 import me.him188.ani.app.ui.settings.framework.components.SliderItem
+import me.him188.ani.app.ui.settings.framework.components.SwitchItem
 import me.him188.ani.app.ui.settings.framework.components.TextItem
 import me.him188.ani.datasources.api.topic.FileSize
 import me.him188.ani.datasources.api.topic.FileSize.Companion.Unspecified
@@ -85,6 +86,12 @@ internal fun SettingsScope.TorrentEngineGroup(
                     torrentSettingsState.update(torrentSettings.copy(uploadRateLimit = it))
                 },
                 title = { Text("上传速度限制") },
+            )
+            SwitchItem(
+                checked = torrentSettings.limitUploadOnMeteredNetwork,
+                onCheckedChange = { torrentSettingsState.update(torrentSettings.copy(limitUploadOnMeteredNetwork = it)) },
+                title = { Text("计费网络限制上传") },
+                description = { Text("在 Android 移动流量或 Windows 计费网络环境下限制 BT 上传为 1 KB/s") }
             )
         }
         val navigator by rememberUpdatedState(LocalNavigator.current)

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/tabs/media/TorrentEngineGroup.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/tabs/media/TorrentEngineGroup.kt
@@ -91,7 +91,7 @@ internal fun SettingsScope.TorrentEngineGroup(
                 checked = torrentSettings.limitUploadOnMeteredNetwork,
                 onCheckedChange = { torrentSettingsState.update(torrentSettings.copy(limitUploadOnMeteredNetwork = it)) },
                 title = { Text("计费网络限制上传") },
-                description = { Text("在 Android 移动流量或 Windows 计费网络环境下限制 BT 上传为 1 KB/s") }
+                description = { Text("在计费网络环境下限制上传速度为 1 KB/s") }
             )
         }
         val navigator by rememberUpdatedState(LocalNavigator.current)


### PR DESCRIPTION
添加 “计费网络限制上传” 选项

开启选项后，在以下网络环境会限制 BT 上传为 1KB/s

* Android 移动数据
* Windows 设定 Wi-Fi 为计费网络或使用移动数据

close #179, 

![image](https://github.com/user-attachments/assets/face3e6a-8fed-4184-a087-c1ed2076caa2)