### PR TITLE
Improve comment editor expand/close UX and icon placement

### DIFF
--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/comments/EpisodeEditCommentSheet.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/comments/EpisodeEditCommentSheet.kt
@@ -53,6 +53,7 @@ fun EpisodeEditCommentSheet(
         EditComment(
             state = state,
             turnstileState = turnstileState,
+            onCloseRequest = onDismiss,
             modifier = modifier
                 .ifThen(state.editExpanded) { statusBarsPadding() }
                 .ifThen(!state.editExpanded) { padding(top = contentPadding) }
@@ -63,7 +64,6 @@ fun EpisodeEditCommentSheet(
                 sheetState.close()
                 onSendComplete()
             },
-            onCloseRequest = onDismiss,
         )
     }
 }

--- a/app/shared/ui-comment/src/commonMain/kotlin/ui/comment/EditComment.kt
+++ b/app/shared/ui-comment/src/commonMain/kotlin/ui/comment/EditComment.kt
@@ -69,8 +69,8 @@ fun EditComment(
     modifier: Modifier = Modifier,
     focusRequester: FocusRequester = remember { FocusRequester() },
     stickerPanelHeight: Dp = EditCommentDefaults.MinStickerHeight.dp,
-    onCloseRequest: () -> Unit = {},
     onSendComplete: () -> Unit = { },
+    onCloseRequest: () -> Unit = { },
 ) {
     val scope = rememberCoroutineScope()
     val keyboard = LocalSoftwareKeyboardController.current
@@ -234,7 +234,7 @@ fun EditCommentScaffold(
     previewing: Boolean,
     actionRow: @Composable ColumnScope.() -> Unit,
     onClickExpand: (Boolean) -> Unit,
-    onClickClose: () -> Unit = {},
+    onClickClose: () -> Unit,
     modifier: Modifier = Modifier,
     expanded: Boolean? = null,
     title: (@Composable () -> Unit)? = null,


### PR DESCRIPTION
## What

This PR improves the UX of the comment editor by:

- Moving the expand/contract toggle to the top-right of the text field
- Using clear icons (`OpenInFull` and `CloseFullscreen`) instead of confusing arrow icons


## Why

- The old arrow-style toggle caused users to mistake it for a close button
- Expand/collapse functionality is now placed closer to the input field for better visibility
- Prevents accidental closure of the editor while writing a comment

## Where

- `EditComment`: Adjusted layout to include the toggle icon inside the editor box
- `EpisodeEditCommentSheet`: Propagates close behavior through `onCloseRequest`

## Note on Testing

This part of the code currently doesn't have an associated unit or UI test.
If testing is required, please advise where such tests should be added

Related issue: #959 