### PR TITLE
feat(ui): 添加根据主题模式动态调整状态栏背景

### DIFF
--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodePage.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodePage.kt
@@ -446,17 +446,15 @@ private fun EpisodeScreenTabletVeryWide(
                     .background(MaterialTheme.colorScheme.background), // scrollable background
             ) {
 
-
                 val themeSettings = LocalThemeSettings.current
-                val isCurrentInDarkTheme: Boolean = when (themeSettings.darkMode) {
-                    DarkMode.DARK -> true
-                    DarkMode.LIGHT -> false
-                    DarkMode.AUTO -> isSystemInDarkTheme()
+                val isEpPageDarkTheme = when {
+                    themeSettings.alwaysDarkInEpisodePage -> true
+                    themeSettings.darkMode == DarkMode.AUTO -> isSystemInDarkTheme()
+                    else -> themeSettings.darkMode == DarkMode.DARK
                 }
                 // 如果当前不是 dark theme 并且 是安卓平台 并且 没有设置播放页始终使用暗色主题，则加一个渐变色避免看不清状态栏
                 // ios 宽屏模式下会自动隐藏状态栏, 无需处理
-                val needShadeBackground =
-                    !isCurrentInDarkTheme && LocalPlatform.current.isAndroid() && !themeSettings.alwaysDarkInEpisodePage
+                val needShadeBackground = !isEpPageDarkTheme && LocalPlatform.current.isAndroid() 
                 // 填充 insets 背景颜色
                 Spacer(
                     Modifier


### PR DESCRIPTION
修改前：
![Screenshot_20250902_154838](https://github.com/user-attachments/assets/b7a09f0f-948d-4b4f-b0f3-12078e874fa4)

优化后：
![Screenshot_20250902_154822](https://github.com/user-attachments/assets/23346aec-d702-4983-b1a9-ba372fa470c6)

只在非全屏的宽屏状态下并当前处于非暗色模式时生效