### PR TITLE
Fix: Remove initial loading state emission to preserve scroll position

### DIFF
--- a/app/shared/ui-subject/src/commonMain/kotlin/ui/subject/collection/CollectionPage.kt
+++ b/app/shared/ui-subject/src/commonMain/kotlin/ui/subject/collection/CollectionPage.kt
@@ -86,7 +86,6 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.paging.CombinedLoadStates
 import androidx.paging.LoadState
-import androidx.paging.LoadStates
 import androidx.paging.PagingData
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectWithLifecycle
@@ -200,16 +199,7 @@ class UserCollectionsState(
                 .restartable(restarter)
                 .map { CollectionsFilterQuery(availableTypes[it]) }
                 .transformLatest { query ->
-                    emit(
-                        PagingData.from(
-                            emptyList<SubjectCollectionInfo>(),
-                            LoadStates(
-                                refresh = LoadState.Loading,
-                                append = LoadState.NotLoading(false),
-                                prepend = LoadState.NotLoading(false),
-                            ),
-                        ),
-                    )
+                    // 不再发射初始加载状态，直接发射真实数据
                     emitAll(startSearch(query))
                 }
 


### PR DESCRIPTION
## What
- Removed initial loading state emission in `getCollectionLazyPagingItems()` method
- Deleted the emit(PagingData.from(...)) call that emitted empty data with `LoadState.Loading`
- Now directly emits real data via `emitAll(startSearch(query))`

## Where
- `CollectionPage.kt`, method `UserCollectionsState.getCollectionLazyPagingItems()`

## Why
- Collection page scrolled back to top when returning from detail page or switching apps
-  Initial loading state emission caused LazyPagingItems to be recreated, making Compose treat it as a new list and reset scroll position

## Related
Closes #2464 
