### PR TITLE
Fixed the "Show More" button issue in the subject details page where the button was not responding correctly when clicked.

### DIFF
--- a/app/shared/ui-subject/src/commonMain/kotlin/ui/subject/details/components/DetailsTab.kt
+++ b/app/shared/ui-subject/src/commonMain/kotlin/ui/subject/details/components/DetailsTab.kt
@@ -267,13 +267,12 @@ private fun TagsList(
                 derivedStateOf {
                     when {
                         isExpanded -> allTags
-                        allTags.size <= 6 -> allTags
                         else -> {
                             val filteredByCount = allTags.filter { it.count > 100 }
-                            if (filteredByCount.size < ALWAYS_SHOW_TAGS_COUNT) {
-                                allTags.take(ALWAYS_SHOW_TAGS_COUNT)
-                            } else {
+                            if (filteredByCount.size <= ALWAYS_SHOW_TAGS_COUNT) {
                                 filteredByCount
+                            } else {
+                                allTags.take(ALWAYS_SHOW_TAGS_COUNT)
                             }
                         }
                     }


### PR DESCRIPTION
## What
Fixed the "Show More" button issue in subject details page tags section.

## Why
The button was not responding correctly due to incorrect logic in presentTags computation using hardcoded values instead of `ALWAYS_SHOW_TAGS_COUNT` constant.

## Where
 In the TagsList composable component in `DetailsTab.kt` file.

## Related
Closes #2498 