### PR TITLE
fix(ui): default widget will be correctly highlighted when entering the settings page

### DIFF
--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/SettingsScreen.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/SettingsScreen.kt
@@ -168,9 +168,6 @@ fun SettingsScreen(
     windowInsets: WindowInsets = AniWindowInsets.forColumnPageContent(),
     navigationIcon: @Composable () -> Unit = {},
 ) {
-    var lastSelectedTab by rememberSaveable {
-        mutableStateOf(initialTab)
-    }
     val navigator: ThreePaneScaffoldNavigator<Nothing?> = rememberListDetailPaneScaffoldNavigator(
         initialDestinationHistory = buildList {
             add(ThreePaneScaffoldDestinationItem(ListDetailPaneScaffoldRole.List))
@@ -180,6 +177,18 @@ fun SettingsScreen(
         },
     )
     val layoutParameters = ListDetailLayoutParameters.calculate(navigator.scaffoldDirective)
+    var lastSelectedTab by rememberSaveable(initialTab, layoutParameters) {
+        mutableStateOf(
+            if (initialTab != null) {
+                initialTab
+            } else if (!layoutParameters.preferSinglePane) {
+                // 宽屏模式（双页布局）且无初始 tab：默认选中 APPEARANCE
+                SettingsTab.APPEARANCE
+            } else {
+                null
+            },
+        )
+    }
     val coroutineScope = rememberCoroutineScope()
     val browserNavigator = rememberAsyncBrowserNavigator()
     val context = LocalContext.current


### PR DESCRIPTION
What
Added a flag to ensure the "Appearance" settings tab is automatically selected and highlighted in wide-screen (list-detail) layout when entering the settings screen without a specified initial tab.

Why
Previously, in wide-screen mode, the settings screen would display the first tab’s content by default but failed to visually highlight it in the navigation rail, leading to a mismatch between the displayed content and the selected UI state. This occurred because the initial selection logic didn’t account for layout context when no initialTab was provided. Users saw the Appearance (or first) tab content but with no navigation item highlighted, causing confusion.

Where
SettingsScreen.kt: Introduced early calculation of layoutParameters and updated the lastSelectedTab initialization logic to default to SettingsTab.APPEARANCE in list-detail (non-single-pane) layouts when initialTab is null.

Close
#2652