### PR TITLE
Try To fix issue#2626

### DIFF
--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodePage.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodePage.kt
@@ -414,7 +414,7 @@ private fun EpisodeScreenTabletVeryWide(
                 danmakuHostState,
                 danmakuEditorState,
                 vm.playerControllerState,
-                expanded = true,
+                expanded = vm.isFullscreen,
                 modifier = Modifier.weight(1f).fillMaxHeight(),
                 maintainAspectRatio = false,
                 windowInsets = if (vm.isFullscreen) {


### PR DESCRIPTION
https://github.com/open-ani/animeko/issues/2626
在横屏/宽屏布局中，EpisodePage.kt 调用 EpisodeVideo 时，将 expanded 参数写死为 true，而全屏状态实际上是由 vm.isFullscreen 控制的。这样会导致播放器在 UI 上始终认为处于“expanded/fullscreen” 状态，因此右下角的全屏按钮图标一直显示为 FullscreenExit，退出全屏后也不会切回“进入全屏”的图标。