### PR TITLE
optimize: ikaros datasource fetch episode attachment resources.

### DIFF
--- a/datasource/ikaros/src/commonMain/kotlin/models/IkarosAttachmentType.kt
+++ b/datasource/ikaros/src/commonMain/kotlin/models/IkarosAttachmentType.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-2025 OpenAni and contributors.
+ * Copyright (C) 2024-2026 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -14,5 +14,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 enum class IkarosAttachmentType {
     File,
-    Directory;
+    Directory,
+    Driver_File,
+    Driver_Directory;
 }


### PR DESCRIPTION
更新了获取剧集资源的方式。

ikaros server 版本大于1.0之后，附件新增了附件驱动的支持，支持挂载本地目录，附件分为驱动类型的附件和普通附件，获取播放地址的接口进行了统一。
- `$baseUrl/api/$API_VERSION/attachment/url/read/id/$attachmentId`: 获取播放地址url，服务端根据附件类型，动态返回url。
- `$baseUrl/api/$API_VERSION/attachment/stream/id/$attachmentId`: 文件流式播放接口，动态获取挂载的附件对应驱动的文件流，比如挂载的本地文件，或者是115网盘。

