### PR TITLE
feat: 添加批量清除无效媒体源功能  issues/2812

### DIFF
--- a/app/shared/app-lang/src/androidMain/res/values-zh-rCN/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values-zh-rCN/strings.xml
@@ -236,6 +236,9 @@
     <string name="settings_media_source_sort">排序</string>
     <string name="settings_media_source_stop_test">终止测试</string>
     <string name="settings_media_source_start_test">开始测试</string>
+    <string name="settings_media_source_clear_invalid">清除无效源(%1$d)</string>
+    <string name="settings_media_source_clear_invalid_confirmation">确定要删除 %1$d 个无效数据源吗？</string>
+    <string name="settings_media_source_clear_invalid_result">已清除 %1$d 个无效源，失败 %2$d 个。</string>
     <string name="settings_media_source_delete">删除数据源</string>
     <string name="settings_media_source_delete_no_config">该数据源无特殊配置，删除后可以重新从模板直接添加，确认删除吗？</string>
     <string name="settings_media_source_delete_with_config">该数据源有配置，删除后将丢失配置，之后从模板添加时需要重新配置，确认删除吗？</string>

--- a/app/shared/app-lang/src/androidMain/res/values-zh-rHK/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values-zh-rHK/strings.xml
@@ -214,6 +214,9 @@
     <string name="settings_media_source_sort">排序</string>
     <string name="settings_media_source_stop_test">終止測試</string>
     <string name="settings_media_source_start_test">開始測試</string>
+    <string name="settings_media_source_clear_invalid">清除無效源(%1$d)</string>
+    <string name="settings_media_source_clear_invalid_confirmation">確定要刪除 %1$d 個無效數據源嗎？</string>
+    <string name="settings_media_source_clear_invalid_result">已清除 %1$d 個無效源，失敗 %2$d 個。</string>
     <string name="settings_media_source_delete">刪除數據源</string>
     <string name="settings_media_source_delete_no_config">該數據源無特殊配置，刪除後可以重新從模板直接添加，確認刪除嗎？</string>
     <string name="settings_media_source_delete_with_config">該數據源有配置，刪除後將丟失配置，之後從模板添加時需要重新配置，確認刪除嗎？</string>

--- a/app/shared/app-lang/src/androidMain/res/values-zh-rTW/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values-zh-rTW/strings.xml
@@ -214,6 +214,9 @@
     <string name="settings_media_source_sort">排序</string>
     <string name="settings_media_source_stop_test">終止測試</string>
     <string name="settings_media_source_start_test">開始測試</string>
+    <string name="settings_media_source_clear_invalid">清除無效來源(%1$d)</string>
+    <string name="settings_media_source_clear_invalid_confirmation">確定要刪除 %1$d 個無效資料來源嗎？</string>
+    <string name="settings_media_source_clear_invalid_result">已清除 %1$d 個無效來源，失敗 %2$d 個。</string>
     <string name="settings_media_source_delete">刪除資料源</string>
     <string name="settings_media_source_delete_no_config">該資料源無特殊配置，刪除後可以重新從模板直接添加，確認刪除嗎？</string>
     <string name="settings_media_source_delete_with_config">該資料源有配置，刪除後將遺失配置，之後從模板添加時需要重新配置，確認刪除嗎？</string>

--- a/app/shared/app-lang/src/androidMain/res/values/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values/strings.xml
@@ -211,6 +211,9 @@
     <string name="settings_media_source_sort">Sort</string>
     <string name="settings_media_source_stop_test">Stop test</string>
     <string name="settings_media_source_start_test">Start test</string>
+    <string name="settings_media_source_clear_invalid">Clear invalid sources (%1$d)</string>
+    <string name="settings_media_source_clear_invalid_confirmation">Delete %1$d invalid data sources?</string>
+    <string name="settings_media_source_clear_invalid_result">Removed %1$d invalid sources, %2$d failed.</string>
     <string name="settings_media_source_delete">Delete data source</string>
     <string name="settings_media_source_delete_no_config">This data source has no special configuration. It can be re-added from a template after deletion. Confirm deletion?</string>
     <string name="settings_media_source_delete_with_config">This data source has configurations. Deleting it will lose those configurations. They must be reconfigured when re-added from a template. Confirm deletion?</string>

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/tabs/media/source/MediaSourceGroup.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/tabs/media/source/MediaSourceGroup.kt
@@ -55,6 +55,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -78,10 +79,14 @@ import me.him188.ani.app.ui.foundation.LocalPlatform
 import me.him188.ani.app.ui.foundation.animation.AniAnimatedVisibility
 import me.him188.ani.app.ui.foundation.ifThen
 import me.him188.ani.app.ui.foundation.interaction.onRightClickIfSupported
+import me.him188.ani.app.ui.foundation.widgets.LocalToaster
 import me.him188.ani.app.ui.lang.Lang
 import me.him188.ani.app.ui.lang.settings_media_source_add
 import me.him188.ani.app.ui.lang.settings_media_source_cancel
 import me.him188.ani.app.ui.lang.settings_media_source_cancel_sort
+import me.him188.ani.app.ui.lang.settings_media_source_clear_invalid
+import me.him188.ani.app.ui.lang.settings_media_source_clear_invalid_confirmation
+import me.him188.ani.app.ui.lang.settings_media_source_clear_invalid_result
 import me.him188.ani.app.ui.lang.settings_media_source_delete
 import me.him188.ani.app.ui.lang.settings_media_source_delete_can_readd
 import me.him188.ani.app.ui.lang.settings_media_source_delete_confirm
@@ -99,6 +104,7 @@ import me.him188.ani.app.ui.lang.settings_media_source_select_template
 import me.him188.ani.app.ui.lang.settings_media_source_sort
 import me.him188.ani.app.ui.lang.settings_media_source_start_test
 import me.him188.ani.app.ui.lang.settings_media_source_stop_test
+import me.him188.ani.app.ui.settings.framework.ConnectionTestResult
 import me.him188.ani.app.ui.settings.framework.ConnectionTesterResultIndicator
 import me.him188.ani.app.ui.settings.framework.components.SettingsScope
 import me.him188.ani.app.ui.settings.framework.components.TextButtonItem
@@ -112,6 +118,7 @@ import org.burnoutcrew.reorderable.ReorderableItem
 import org.burnoutcrew.reorderable.detectReorder
 import org.burnoutcrew.reorderable.detectReorderAfterLongPress
 import org.burnoutcrew.reorderable.reorderable
+import org.jetbrains.compose.resources.getString
 import org.jetbrains.compose.resources.stringResource
 
 @Stable
@@ -127,7 +134,9 @@ internal fun SettingsScope.MediaSourceGroup(
 ) {
     val navigator = LocalNavigator.current
     val uiScope = rememberCoroutineScope()
+    val toaster = LocalToaster.current
     var showSelectTemplate by remember { mutableStateOf(false) }
+    var showConfirmClearDialog by rememberSaveable { mutableStateOf(false) }
     if (showSelectTemplate) {
         // 选一个数据源来添加
         SelectMediaSourceTemplateDialog(
@@ -170,6 +179,16 @@ internal fun SettingsScope.MediaSourceGroup(
     val sorter = rememberSorterState<MediaSourcePresentation>(
         onComplete = { list -> state.reorderMediaSources(newOrder = list.map { it.instanceId }) },
     )
+    val isEditTaskRunning by edit.isEditTaskRunning.collectAsState()
+    val canMutateMediaSources = !isEditTaskRunning
+    val invalidSources = state.mediaSources.filter {
+        it.connectionTester.result == ConnectionTestResult.FAILED
+    }
+    val showClearButton = invalidSources.isNotEmpty() &&
+            !state.mediaSourceTesters.anyTesting &&
+            canMutateMediaSources &&
+            !sorter.isSorting
+    val platform = LocalPlatform.current
 
     Group(
         title = { Text(stringResource(Lang.settings_media_source_list, state.mediaSources.size)) },
@@ -196,6 +215,7 @@ internal fun SettingsScope.MediaSourceGroup(
                             edit.cancelEdit()
                             showSelectTemplate = true
                         },
+                        enabled = canMutateMediaSources,
                     ) {
                         Icon(Icons.Rounded.Add, contentDescription = stringResource(Lang.settings_media_source_add))
                     }
@@ -229,6 +249,58 @@ internal fun SettingsScope.MediaSourceGroup(
             }
         },
     ) {
+        if (showConfirmClearDialog) {
+            AlertDialog(
+                onDismissRequest = { showConfirmClearDialog = false },
+                icon = { Icon(Icons.Rounded.Delete, null, tint = MaterialTheme.colorScheme.error) },
+                title = {
+                    Text(
+                        stringResource(
+                            Lang.settings_media_source_clear_invalid,
+                            invalidSources.size,
+                        ),
+                    )
+                },
+                text = {
+                    Text(
+                        stringResource(
+                            Lang.settings_media_source_clear_invalid_confirmation,
+                            invalidSources.size,
+                        ),
+                    )
+                },
+                confirmButton = {
+                    TextButton(
+                        {
+                            val targets = invalidSources.toList()
+                            edit.deleteMediaSources(targets) { result ->
+                                toaster.toast(
+                                    getString(
+                                        Lang.settings_media_source_clear_invalid_result,
+                                        result.deleted,
+                                        result.failed,
+                                    ),
+                                )
+                            }
+                            showConfirmClearDialog = false
+                        },
+                    ) {
+                        Text(
+                            stringResource(Lang.settings_media_source_delete_confirm),
+                            color = MaterialTheme.colorScheme.error,
+                        )
+                    }
+                },
+                dismissButton = {
+                    TextButton(
+                        {
+                            showConfirmClearDialog = false
+                        },
+                    ) { Text(stringResource(Lang.settings_media_source_cancel)) }
+                },
+            )
+        }
+
         Box {
             Column(
                 Modifier
@@ -246,7 +318,6 @@ internal fun SettingsScope.MediaSourceGroup(
                             edit.startEditing(item)
                         }
                     }
-                    val platform = LocalPlatform.current
 
                     var showMoreDropdown by remember { mutableStateOf(false) }
                     var showConfirmDeletionDialog by rememberSaveable { mutableStateOf(false) }
@@ -268,6 +339,7 @@ internal fun SettingsScope.MediaSourceGroup(
                                         edit.deleteMediaSource(item);
                                         showConfirmDeletionDialog = false
                                     },
+                                    enabled = canMutateMediaSources,
                                 ) {
                                     Text(
                                         stringResource(Lang.settings_media_source_delete_confirm),
@@ -288,6 +360,7 @@ internal fun SettingsScope.MediaSourceGroup(
                     MediaSourceItem(
                         item,
                         Modifier.combinedClickable(
+                            enabled = canMutateMediaSources,
                             onClickLabel = "编辑",
                             onLongClick = {
                                 if (platform.isMobile()) {
@@ -297,7 +370,9 @@ internal fun SettingsScope.MediaSourceGroup(
                             onLongClickLabel = "开始排序",
                             onClick = startEditing,
                         ).onRightClickIfSupported {
-                            showMoreDropdown = true
+                            if (canMutateMediaSources) {
+                                showMoreDropdown = true
+                            }
                         },
                     ) {
                         IconButton({}, enabled = false) { // 放在 button 里保持 padding 一致
@@ -308,7 +383,10 @@ internal fun SettingsScope.MediaSourceGroup(
                         }
 
                         Box {
-                            IconButton(onClick = { showMoreDropdown = true }) {
+                            IconButton(
+                                onClick = { showMoreDropdown = true },
+                                enabled = canMutateMediaSources,
+                            ) {
                                 Icon(
                                     Icons.Rounded.MoreVert,
                                     contentDescription = "更多",
@@ -317,6 +395,7 @@ internal fun SettingsScope.MediaSourceGroup(
 
                             MoreOptionsDropdown(
                                 showMoreDropdown,
+                                enabled = canMutateMediaSources,
                                 onDismissRequest = { showMoreDropdown = false },
                                 onDeleteRequest = { showConfirmDeletionDialog = true },
                                 item,
@@ -368,6 +447,18 @@ internal fun SettingsScope.MediaSourceGroup(
 
         HorizontalDividerItem()
 
+        if (showClearButton) {
+            TextButtonItem(
+                onClick = { showConfirmClearDialog = true },
+                title = {
+                    Text(
+                        stringResource(Lang.settings_media_source_clear_invalid, invalidSources.size),
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                },
+            )
+            HorizontalDividerItem()
+        }
 
         TextButtonItem(
             onClick = {
@@ -471,6 +562,7 @@ internal fun SettingsScope.MediaSourceItem(
 @Composable
 private fun MoreOptionsDropdown(
     showMore: Boolean,
+    enabled: Boolean,
     onDismissRequest: () -> Unit,
     onDeleteRequest: () -> Unit,
     item: MediaSourcePresentation,
@@ -482,6 +574,7 @@ private fun MoreOptionsDropdown(
         onDismissRequest = onDismissRequest,
     ) {
         DropdownMenuItem(
+            enabled = enabled,
             leadingIcon = {
                 if (item.isEnabled) {
                     Icon(Icons.Rounded.VisibilityOff, null)
@@ -502,6 +595,7 @@ private fun MoreOptionsDropdown(
             },
         )
         DropdownMenuItem(
+            enabled = enabled,
             leadingIcon = { Icon(Icons.Rounded.Edit, null) },
             text = { Text(stringResource(Lang.settings_media_source_edit)) }, // 直接点击数据源一行也可以编辑, 但还是在这里放一个按钮以免有人不知道
             onClick = {
@@ -510,6 +604,7 @@ private fun MoreOptionsDropdown(
             },
         )
         DropdownMenuItem(
+            enabled = enabled,
             leadingIcon = { Icon(Icons.Rounded.Delete, null, tint = MaterialTheme.colorScheme.error) },
             text = {
                 Text(

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/tabs/media/source/MediaSourceGroupState.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/tabs/media/source/MediaSourceGroupState.kt
@@ -191,7 +191,7 @@ class EditMediaSourceState(
     }
 
     private val editTasker = MonoTasker(backgroundScope)
-    val isEditTaskRunning get() = editTasker.isRunning
+    val editTaskRunningFlow get() = editTasker.isRunning
 
     fun confirmEdit(state: EditingMediaSource): Job {
         return editTasker.launch {


### PR DESCRIPTION
变更内容：
新增“清除无效媒体源”功能，用于批量删除连接测试结果为 FAILED 的数据源。
当存在无效源，且当前未在测试、编辑或排序状态时，显示“清除无效源(n)”按钮
点击后弹出确认对话框
确认后批量删除，并提示删除成功与失败数量

代码修改：
MediaSourceGroup
  新增无效源筛选与按钮显示逻辑
  新增批量删除确认对话框
  调用批量删除接口并显示结果提示

MediaSourceGroupState
  新增 deleteMediaSources 方法及结果统计结构

补充中英文及繁体多语言字符串资源