### PR TITLE
fix(video-player): 修复视频播放内存泄漏问题(issue#2918)

### DIFF
--- a/app/shared/video-player/src/desktopMain/kotlin/ui/ComposeMediaPlayerComponent.kt
+++ b/app/shared/video-player/src/desktopMain/kotlin/ui/ComposeMediaPlayerComponent.kt
@@ -318,20 +318,26 @@ open class ComposeMediaPlayerComponent @JvmOverloads constructor(
         }
     }
 
-    var composeImage: ImageBitmap by mutableStateOf(ImageBitmap(128, 128))
+    var composeImage: ImageBitmap? by mutableStateOf(null)
 
     /**
      * Default implementation of a render callback that copies video frame data directly to the data buffer of an image
      * raster.
      */
     private inner class DefaultRenderCallback : RenderCallbackAdapter() {
+        private var cachedImage: ImageBitmap? = null
+        
         fun setImageBuffer(image: BufferedImage) {
             setBuffer((image.raster.dataBuffer as DataBufferInt).data)
         }
 
         override fun onDisplay(mediaPlayer: MediaPlayer, buffer: IntArray) {
             image?.let {
-                composeImage = it.toComposeImageBitmap()
+                if (cachedImage == null) {
+                    cachedImage = it.toComposeImageBitmap()
+                }
+                composeImage = null
+                composeImage = cachedImage
             }
 //            videoSurfaceComponent!!.repaint()
         }

--- a/app/shared/video-player/src/desktopMain/kotlin/ui/SkiaBitmapVideoSurface.kt
+++ b/app/shared/video-player/src/desktopMain/kotlin/ui/SkiaBitmapVideoSurface.kt
@@ -37,6 +37,10 @@ class SkiaBitmapVideoSurface : VideoSurface(VideoSurfaceAdapters.getVideoSurface
     private lateinit var frameBytes: ByteArray
     private val skiaBitmap: Bitmap = Bitmap()
     private val composeBitmap = mutableStateOf<ImageBitmap?>(null)
+    
+    private var cachedBitmap: ImageBitmap? = null
+    private var lastWidth = 0
+    private var lastHeight = 0
 
     val enableRendering = MutableStateFlow(false)
 
@@ -48,6 +52,7 @@ class SkiaBitmapVideoSurface : VideoSurface(VideoSurfaceAdapters.getVideoSurface
 
     fun clearBitmap() {
         composeBitmap.value = null
+        cachedBitmap = null
     }
 
     override fun attach(mediaPlayer: MediaPlayer) {
@@ -72,6 +77,12 @@ class SkiaBitmapVideoSurface : VideoSurface(VideoSurfaceAdapters.getVideoSurface
                 ColorType.BGRA_8888,
                 ColorAlphaType.PREMUL,
             )
+            
+            if (lastWidth != sourceWidth || lastHeight != sourceHeight) {
+                cachedBitmap = null
+                lastWidth = sourceWidth
+                lastHeight = sourceHeight
+            }
         }
     }
 
@@ -96,7 +107,13 @@ class SkiaBitmapVideoSurface : VideoSurface(VideoSurfaceAdapters.getVideoSurface
                 nativeBuffers[0].rewind()
                 nativeBuffers[0].get(frameBytes)
                 skiaBitmap.installPixels(imageInfo, frameBytes, bufferFormat.width * 4)
-                composeBitmap.value = skiaBitmap.asComposeImageBitmap()
+                
+                if (cachedBitmap == null) {
+                    cachedBitmap = skiaBitmap.asComposeImageBitmap()
+                }
+                
+                composeBitmap.value = null
+                composeBitmap.value = cachedBitmap
             }
         }
     }


### PR DESCRIPTION
引入缓存机制避免重复创建ImageBitmap对象，减少内存分配和GC压力。修改ComposeMediaPlayerComponent和SkiaBitmapVideoSurface，仅在视频尺寸变化时重新创建位图，其他情况复用缓存对象。

我根据日志提供的信息，去代码里找原因。看了两个文件：

### SkiaBitmapVideoSurface.kt
```
composeBitmap.value = skiaBitmap.
asComposeImageBitmap()
```
这行代码每帧都会创建一个新的 ImageBitmap 对象。视频是 60 帧每秒，所以每秒就创建 60 个 ImageBitmap。旧的 ImageBitmap 没清理，就一直占着内存。

### ComposeMediaPlayerComponent.kt
```
composeImage = it.
toComposeImageBitmap()
```
这里也是一样，每帧都创建新的 ImageBitmap。

## 为什么会内存泄漏(可能的原因)
ImageBitmap 对象被创建后，虽然旧的已经不用了，但还被引用着，所以 GC（垃圾回收）没法清理它们。这些 ImageBitmap 不光占用 JVM 堆内存，还占用本地内存（Native Memory），所以内存涨得特别快。