### PR TITLE
fix(player): 修复进度条拖动回跳问题

### DIFF
--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodePage.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodePage.kt
@@ -160,6 +160,7 @@ import me.him188.ani.utils.platform.isAndroid
 import me.him188.ani.utils.platform.isDesktop
 import me.him188.ani.utils.platform.isIos
 import me.him188.ani.utils.platform.isMobile
+import org.openani.mediamp.PlaybackState
 import org.openani.mediamp.features.AudioLevelController
 import org.openani.mediamp.features.PlaybackSpeed
 import org.openani.mediamp.features.Screenshots
@@ -350,6 +351,7 @@ private fun EpisodeScreenContent(
                                 pauseOnPlaying = pauseOnPlaying,
                                 tryUnpause = tryUnpause,
                                 setShowEditCommentSheet = { showEditCommentSheet = it },
+                                playbackState = playbackState,
                                 modifier = Modifier.fillMaxSize(),
                                 windowInsets = windowInsets,
                             )
@@ -363,6 +365,7 @@ private fun EpisodeScreenContent(
                             pauseOnPlaying = pauseOnPlaying,
                             tryUnpause = tryUnpause,
                             setShowEditCommentSheet = { showEditCommentSheet = it },
+                            playbackState = playbackState,
                             windowInsets,
                         )
                     }
@@ -403,6 +406,7 @@ private fun EpisodeScreenTabletVeryWide(
     pauseOnPlaying: () -> Unit,
     tryUnpause: () -> Unit,
     setShowEditCommentSheet: (Boolean) -> Unit,
+    playbackState: PlaybackState,
     modifier: Modifier = Modifier,
     windowInsets: WindowInsets = ScaffoldDefaults.contentWindowInsets,
 ) {
@@ -423,6 +427,7 @@ private fun EpisodeScreenTabletVeryWide(
                 danmakuEditorState,
                 vm.playerControllerState,
                 expanded = true,
+                playbackState = playbackState,
                 modifier = Modifier.weight(1f).fillMaxHeight(),
                 maintainAspectRatio = false,
                 windowInsets = if (vm.isFullscreen) {
@@ -624,6 +629,7 @@ private fun EpisodeScreenContentPhone(
     pauseOnPlaying: () -> Unit,
     tryUnpause: () -> Unit,
     setShowEditCommentSheet: (Boolean) -> Unit,
+    playbackState: PlaybackState,
     windowInsets: WindowInsets = ScaffoldDefaults.contentWindowInsets,
 ) {
     var showDanmakuEditor by rememberSaveable { mutableStateOf(false) }
@@ -648,6 +654,7 @@ private fun EpisodeScreenContentPhone(
                 vm, page,
                 danmakuHostState,
                 danmakuEditorState, vm.playerControllerState, vm.isFullscreen,
+                playbackState = playbackState,
                 windowInsets = videoWindowInsets,
             )
         },
@@ -862,6 +869,7 @@ private fun EpisodeVideo(
     danmakuEditorState: DanmakuEditorState,
     playerControllerState: PlayerControllerState,
     expanded: Boolean,
+    playbackState: PlaybackState,
     modifier: Modifier = Modifier,
     maintainAspectRatio: Boolean = !expanded,
     windowInsets: WindowInsets = ScaffoldDefaults.contentWindowInsets,
@@ -895,9 +903,25 @@ private fun EpisodeVideo(
     // 定期检查 seek 是否完成，解决进度条回跳问题
     // 在播放器实际位置到达目标位置前，保持显示预览位置
     LaunchedEffect(progressSliderState) {
-        while (true) {
-            delay(100)
-            progressSliderState.checkSeekingComplete()
+
+        try {
+            while (true) {
+                delay(100)
+                if (progressSliderState.isSeeking) {
+                    progressSliderState.checkSeekingComplete()
+                }
+            }
+        } catch (e: Exception) {
+            // 处理异常，避免协程崩溃
+            e.printStackTrace()
+        }
+    }
+
+    // 监听播放器状态变化，当播放器停止时重置 isSeeking 状态
+    LaunchedEffect(playbackState) {
+        if (!playbackState.isPlaying) {
+            // 播放器停止时，重置 isSeeking 状态
+            progressSliderState?.resetSeeking()
         }
     }
     

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodePage.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodePage.kt
@@ -77,6 +77,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
@@ -890,6 +891,16 @@ private fun EpisodeVideo(
             vm.player.seekTo(it)
         },
     )
+    
+    // 定期检查 seek 是否完成，解决进度条回跳问题
+    // 在播放器实际位置到达目标位置前，保持显示预览位置
+    LaunchedEffect(progressSliderState) {
+        while (true) {
+            delay(100)
+            progressSliderState.checkSeekingComplete()
+        }
+    }
+    
     val scope = rememberCoroutineScope()
 
     // 必须在 UI 里, 跟随 context 变化. 否则 #958

--- a/app/shared/src/desktopTest/kotlin/ui/progress/PlayerProgressSliderStateTest.kt
+++ b/app/shared/src/desktopTest/kotlin/ui/progress/PlayerProgressSliderStateTest.kt
@@ -11,7 +11,6 @@ package me.him188.ani.app.ui.progress
 
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import kotlinx.collections.immutable.persistentListOf
 import me.him188.ani.app.ui.framework.runComposeStateTest
@@ -20,6 +19,8 @@ import me.him188.ani.app.videoplayer.ui.progress.PlayerProgressSliderState
 import org.openani.mediamp.metadata.Chapter
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class PlayerProgressSliderStateTest {
 
@@ -33,8 +34,8 @@ class PlayerProgressSliderStateTest {
             totalDurationMillis = { 100_000L },
             chapters = { chapters },
             onPreview = {},
-            onPreviewFinished = {
-                positionState = it
+            onPreviewFinished = { position ->
+                positionState = position
             },
         )
 
@@ -42,6 +43,21 @@ class PlayerProgressSliderStateTest {
         state.finishPreview()
         takeSnapshot()
         assertEquals(0.5f, state.displayPositionRatio)
+        assertTrue(state.isPreviewing)
+        
+        // 播放器位置增加，但未到达目标位置，进度条仍然保持目标位置
+        positionState += 5_000L
+        takeSnapshot()
+        assertEquals(0.5f, state.displayPositionRatio)
+        assertTrue(state.isPreviewing)
+        
+        // 模拟播放器到达目标位置
+        positionState = 50_000L
+        state.checkSeekingComplete()
+        takeSnapshot()
+        assertFalse(state.isPreviewing)
+        
+        // 之后再增加位置，进度条跟随
         positionState += 5_000L
         takeSnapshot()
         assertEquals(0.55f, state.displayPositionRatio)
@@ -57,8 +73,8 @@ class PlayerProgressSliderStateTest {
             totalDurationMillis = { 100_000L },
             chapters = { chapters },
             onPreview = {},
-            onPreviewFinished = {
-                positionState = it
+            onPreviewFinished = { position ->
+                positionState = position
             },
         )
 
@@ -69,6 +85,21 @@ class PlayerProgressSliderStateTest {
         state.finishPreview()
         takeSnapshot()
         assertEquals(0.5f, state.displayPositionRatio)
+        assertTrue(state.isPreviewing)
+        
+        // 播放器位置增加，但未到达目标位置，进度条仍然保持目标位置
+        positionState += 5_000L
+        takeSnapshot()
+        assertEquals(0.5f, state.displayPositionRatio)
+        assertTrue(state.isPreviewing)
+        
+        // 模拟播放器到达目标位置
+        positionState = 50_000L
+        state.checkSeekingComplete()
+        takeSnapshot()
+        assertFalse(state.isPreviewing)
+        
+        // 之后再增加位置，进度条跟随
         positionState += 5_000L
         takeSnapshot()
         assertEquals(0.55f, state.displayPositionRatio)

--- a/app/shared/video-player/src/commonMain/kotlin/ui/progress/MediaProgressSlider.kt
+++ b/app/shared/video-player/src/commonMain/kotlin/ui/progress/MediaProgressSlider.kt
@@ -109,7 +109,7 @@ class PlayerProgressSliderState(
     /** 目标跳转位置（毫秒），用于在 seek 完成前显示预览位置 */
     private var targetPositionMillis: Long by mutableLongStateOf(0L)
     /** 是否正在执行 seek 操作，seek 期间继续显示目标位置 */
-    private var isSeeking: Boolean by mutableStateOf(false)
+    var isSeeking: Boolean by mutableStateOf(false)
     /** 记录最后一次 seek 的位置，忽略中间的 seek 完成 */
     private var lastSeekPositionMillis: Long by mutableLongStateOf(0L)
 
@@ -153,6 +153,8 @@ class PlayerProgressSliderState(
     /**
      * 用户松开进度条时调用。
      * 记录目标位置并启动 seek 状态，在播放器实际位置到达目标位置前继续显示预览位置。
+     * 直接执行 seekTo 操作，因为 lastSeekPositionMillis 已经记录了最后一次的目标位置
+     * 即使多次调用，播放器最终也会停在最后一次的目标位置
      */
     fun finishPreview() {
         val ratio = this.previewPositionRatio
@@ -164,6 +166,8 @@ class PlayerProgressSliderState(
         isSeeking = true
         previewPositionRatio = Float.NaN
         
+        // 直接执行 seekTo 操作
+        // 即使多次调用，播放器最终也会停在最后一次的目标位置
         onPreviewFinished(targetPosition)
     }
 
@@ -172,14 +176,27 @@ class PlayerProgressSliderState(
      * 当播放器当前位置接近目标位置（误差 < 500ms）或超过目标位置时，
      * 结束 seeking 状态，进度条恢复正常显示。
      * 只在播放器位置接近最后一次 seek 的位置时才结束 seeking。
+     * 即使播放器执行 seekTo 操作的顺序与调用顺序不一致，
+     * 也能确保最终停在最后一次选择的位置。
      */
     fun checkSeekingComplete() {
         if (!isSeeking) return
         
         val diff = kotlin.math.abs(currentPositionMillis - lastSeekPositionMillis)
         if (diff < 500L || currentPositionMillis >= lastSeekPositionMillis) {
+            // 只有当播放器位置接近最后一次 seek 的位置时，才结束 seeking 状态
+            // 这样即使播放器执行 seekTo 操作的顺序与调用顺序不一致，
+            // 也能确保最终停在最后一次选择的位置
             isSeeking = false
         }
+    }
+    
+    /**
+     * 重置 seeking 状态。
+     * 当播放器停止时调用，确保 seek 状态被正确清除。
+     */
+    fun resetSeeking() {
+        isSeeking = false
     }
 }
 

--- a/app/shared/video-player/src/commonMain/kotlin/ui/progress/MediaProgressSlider.kt
+++ b/app/shared/video-player/src/commonMain/kotlin/ui/progress/MediaProgressSlider.kt
@@ -33,6 +33,7 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
@@ -105,10 +106,20 @@ class PlayerProgressSliderState(
     val chapters by derivedStateOf(chapters)
 
     private var previewPositionRatio: Float by mutableFloatStateOf(Float.NaN)
+    /** 目标跳转位置（毫秒），用于在 seek 完成前显示预览位置 */
+    private var targetPositionMillis: Long by mutableLongStateOf(0L)
+    /** 是否正在执行 seek 操作，seek 期间继续显示目标位置 */
+    private var isSeeking: Boolean by mutableStateOf(false)
+    /** 记录最后一次 seek 的位置，忽略中间的 seek 完成 */
+    private var lastSeekPositionMillis: Long by mutableLongStateOf(0L)
 
     val isPreviewing: Boolean by derivedStateOf {
-        !previewPositionRatio.isNaN()
+        !previewPositionRatio.isNaN() || isSeeking
     }
+
+    /** 目标位置的进度比例（0-1），用于 seek 期间显示进度条位置 */
+    private val targetPositionRatio: Float
+        get() = if (totalDurationMillis == 0L) 0f else targetPositionMillis.toFloat() / totalDurationMillis
 
     /**
      * Sets the slider to move to the given position.
@@ -128,6 +139,10 @@ class PlayerProgressSliderState(
             return@derivedStateOf previewPositionRatio
         }
 
+        if (isSeeking) {
+            return@derivedStateOf targetPositionRatio
+        }
+
         val total = this.totalDurationMillis
         if (total == 0L) {
             return@derivedStateOf 0f
@@ -135,11 +150,36 @@ class PlayerProgressSliderState(
         this.currentPositionMillis.toFloat() / total
     }
 
+    /**
+     * 用户松开进度条时调用。
+     * 记录目标位置并启动 seek 状态，在播放器实际位置到达目标位置前继续显示预览位置。
+     */
     fun finishPreview() {
         val ratio = this.previewPositionRatio
         if (ratio.isNaN()) return
-        onPreviewFinished((ratio * totalDurationMillis).roundToLong())
+        
+        val targetPosition = (ratio * totalDurationMillis).roundToLong()
+        targetPositionMillis = targetPosition
+        lastSeekPositionMillis = targetPosition  // 记录最后一次 seek 的位置
+        isSeeking = true
         previewPositionRatio = Float.NaN
+        
+        onPreviewFinished(targetPosition)
+    }
+
+    /**
+     * 检查 seek 操作是否完成。
+     * 当播放器当前位置接近目标位置（误差 < 500ms）或超过目标位置时，
+     * 结束 seeking 状态，进度条恢复正常显示。
+     * 只在播放器位置接近最后一次 seek 的位置时才结束 seeking。
+     */
+    fun checkSeekingComplete() {
+        if (!isSeeking) return
+        
+        val diff = kotlin.math.abs(currentPositionMillis - lastSeekPositionMillis)
+        if (diff < 500L || currentPositionMillis >= lastSeekPositionMillis) {
+            isSeeking = false
+        }
     }
 }
 

--- a/app/shared/video-player/src/commonTest/kotlin/ui/progress/PlayerProgressSliderStateTest.kt
+++ b/app/shared/video-player/src/commonTest/kotlin/ui/progress/PlayerProgressSliderStateTest.kt
@@ -1,0 +1,184 @@
+/*
+ * Copyright (C) 2024 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.videoplayer.ui.progress
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.setValue
+import kotlinx.collections.immutable.persistentListOf
+import me.him188.ani.app.ui.framework.runComposeStateTest
+import me.him188.ani.app.ui.framework.takeSnapshot
+import org.openani.mediamp.metadata.Chapter
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PlayerProgressSliderStateTest {
+
+    @Test
+    fun `test basic seek operation`() = runComposeStateTest {
+        val chapters = persistentListOf<Chapter>()
+        var positionState by mutableLongStateOf(0L)
+
+        val state = PlayerProgressSliderState(
+            currentPositionMillis = { positionState },
+            totalDurationMillis = { 100_000L },
+            chapters = { chapters },
+            onPreview = {},
+            onPreviewFinished = { position ->
+                positionState = position
+            },
+        )
+
+        // 拖动到 50% 位置
+        state.previewPositionRatio(0.5f)
+        state.finishPreview()
+        takeSnapshot()
+        
+        // 验证显示位置是 50%
+        assertEquals(0.5f, state.displayPositionRatio)
+        // 验证 isSeeking 状态
+        assertTrue(state.isPreviewing)
+
+        // 模拟播放器位置更新到目标位置
+        positionState = 50_000L
+        state.checkSeekingComplete()
+        takeSnapshot()
+        
+        // 验证 isSeeking 状态结束
+        assertFalse(state.isPreviewing)
+        assertEquals(0.5f, state.displayPositionRatio)
+    }
+
+    @Test
+    fun `test rapid consecutive drag operations`() = runComposeStateTest {
+        val chapters = persistentListOf<Chapter>()
+        var positionState by mutableLongStateOf(0L)
+        var lastSeekPosition: Long = 0L
+
+        val state = PlayerProgressSliderState(
+            currentPositionMillis = { positionState },
+            totalDurationMillis = { 100_000L },
+            chapters = { chapters },
+            onPreview = {},
+            onPreviewFinished = { position ->
+                lastSeekPosition = position
+                // 模拟播放器延迟更新
+            },
+        )
+
+        // 第一次拖动到 A 点 (30%)
+        state.previewPositionRatio(0.3f)
+        state.finishPreview()
+        takeSnapshot()
+        assertEquals(0.3f, state.displayPositionRatio)
+        assertTrue(state.isPreviewing)
+        assertEquals(30_000L, lastSeekPosition)
+
+        // 快速第二次拖动到 B 点 (70%)
+        state.previewPositionRatio(0.7f)
+        state.finishPreview()
+        takeSnapshot()
+        
+        // 验证显示位置是 B 点，不是 A 点
+        assertEquals(0.7f, state.displayPositionRatio)
+        assertTrue(state.isPreviewing)
+        assertEquals(70_000L, lastSeekPosition)
+
+        // 模拟播放器位置更新到 A 点（中间位置）
+        positionState = 30_000L
+        state.checkSeekingComplete()
+        takeSnapshot()
+        
+        // 验证 isSeeking 状态仍然为 true（因为还没到最后一次的目标位置）
+        assertTrue(state.isPreviewing)
+        // 验证显示位置仍然是 B 点
+        assertEquals(0.7f, state.displayPositionRatio)
+
+        // 模拟播放器位置更新到 B 点
+        positionState = 70_000L
+        state.checkSeekingComplete()
+        takeSnapshot()
+        
+        // 验证 isSeeking 状态结束
+        assertFalse(state.isPreviewing)
+        // 验证显示位置是 B 点
+        assertEquals(0.7f, state.displayPositionRatio)
+    }
+
+    @Test
+    fun `test seek completion detection`() = runComposeStateTest {
+        val chapters = persistentListOf<Chapter>()
+        var positionState by mutableLongStateOf(0L)
+
+        val state = PlayerProgressSliderState(
+            currentPositionMillis = { positionState },
+            totalDurationMillis = { 100_000L },
+            chapters = { chapters },
+            onPreview = {},
+            onPreviewFinished = { position ->
+                positionState = position
+            },
+        )
+
+        // 拖动到 60% 位置
+        state.previewPositionRatio(0.6f)
+        state.finishPreview()
+        takeSnapshot()
+
+        // 模拟播放器位置接近目标位置（误差 < 500ms）
+        positionState = 60_200L
+        state.checkSeekingComplete()
+        takeSnapshot()
+        
+        // 验证 isSeeking 状态结束
+        assertFalse(state.isPreviewing)
+
+        // 再次拖动到 80% 位置
+        state.previewPositionRatio(0.8f)
+        state.finishPreview()
+        takeSnapshot()
+        assertTrue(state.isPreviewing)
+
+        // 模拟播放器位置超过目标位置
+        positionState = 80_500L
+        state.checkSeekingComplete()
+        takeSnapshot()
+        
+        // 验证 isSeeking 状态结束
+        assertFalse(state.isPreviewing)
+    }
+
+    @Test
+    fun `test no seeking when preview ratio is NaN`() = runComposeStateTest {
+        val chapters = persistentListOf<Chapter>()
+        var positionState by mutableLongStateOf(0L)
+        var seekCalled = false
+
+        val state = PlayerProgressSliderState(
+            currentPositionMillis = { positionState },
+            totalDurationMillis = { 100_000L },
+            chapters = { chapters },
+            onPreview = {},
+            onPreviewFinished = {
+                seekCalled = true
+            },
+        )
+
+        // 调用 finishPreview 但没有设置预览位置
+        state.finishPreview()
+        takeSnapshot()
+        
+        // 验证 seek 没有被调用
+        assertFalse(seekCalled)
+        assertFalse(state.isPreviewing)
+    }
+}


### PR DESCRIPTION
### 问题原因
这个问题的根本原因是 异步操作导致的竞态条件 ：

1. 用户松开进度条时， seekTo() 被调用，但这是一个异步操作
2. 播放器的实际位置不会立即更新，需要一定时间（通常 100-300ms）
3. 但进度条的状态会立即重置，导致它显示的是旧的播放位置
4. 直到播放器位置真正更新后，进度条才显示新位置
快速拖动的问题 ：

- 拖动到 A 点松开 → seekTo(A) 被调用
- 拖动到 B 点松开 → seekTo(B) 被调用
- 播放器可能先完成 A 的 seek，导致短暂跳到 A
- 进度条检测到位置接近 A，结束 seeking 状态
- 但用户期望的是 B 点，造成混淆
### 解决方案
引入"Seeking 状态"来保持进度条显示的一致性：

- 当用户松开进度条时，记录目标位置并标记为"正在 Seeking"
- 在 Seeking 期间，进度条继续显示目标位置，而不是实际播放位置
- 记录 最后一次 seek 的位置 ，忽略中间的 seek 完成
- 只在播放器位置接近 最后一次 seek 的位置 时，才结束 Seeking 状态
- 恢复正常显示逻辑
### 修改效果
修改前：

- 拖动进度条到 2:00 → 松开手指 → 进度条瞬间跳回 1:00 → 等待 → 进度条跳到 2:00
- 快速拖动 A→B → 进度条可能短暂跳回 A 点
修改后：

- 拖动进度条到 2:00 → 松开手指 → 进度条保持显示 2:00 → 播放器位置到达 2:00 → 正常播放
- 快速拖动 A→B → 进度条保持显示 B 点，不会跳回 A