### PR TITLE
feat(search): add date sort option with client-side sorting

### DIFF
--- a/app/shared/app-data/src/commonMain/kotlin/data/repository/subject/SubjectSearchRepository.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/repository/subject/SubjectSearchRepository.kt
@@ -124,6 +124,7 @@ class SubjectSearchRepository(
                 SearchSort.MATCH -> BangumiSort.MATCH
                 SearchSort.RANK -> BangumiSort.SCORE // 不能用 RANK, bangumi 会把 #0 也包含, 排在最前
                 SearchSort.COLLECTION -> BangumiSort.HEAT
+                SearchSort.DATE -> BangumiSort.MATCH // sorted client-side by airDate
             }
         }
 
@@ -161,6 +162,7 @@ class SubjectSearchRepository(
         ): List<BatchSubjectDetails> {
             return when (sort) {
                 SearchSort.RANK -> subjects.filter { it.subjectInfo.ratingInfo.total >= 50 }
+                SearchSort.DATE -> subjects.sortedByDescending { it.subjectInfo.airDate }
                 SearchSort.MATCH,
                 SearchSort.COLLECTION -> subjects
             }

--- a/app/shared/app-data/src/commonMain/kotlin/domain/search/SubjectSearchQuery.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/search/SubjectSearchQuery.kt
@@ -50,6 +50,11 @@ enum class SearchSort {
      * 收藏人数
      */
     COLLECTION,
+
+    /**
+     * 发布日期
+     */
+    DATE,
 }
 
 data class RatingRange(

--- a/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/search/SearchPageResultColumn.kt
+++ b/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/search/SearchPageResultColumn.kt
@@ -463,4 +463,5 @@ private fun getSortText(currentSort: SearchSort): String = when (currentSort) {
     SearchSort.MATCH -> "最佳匹配"
     SearchSort.COLLECTION -> "最多收藏"
     SearchSort.RANK -> "最高排名"
+    SearchSort.DATE -> "发布日期"
 }


### PR DESCRIPTION
 ---
  Description

  Add a "发布日期" (Release Date) sort option to the subject search results page. Since the Bangumi API does not support date sorting
   natively, results are sorted client-side by airDate in descending order (newest first).

  Fixes #2845

  Reasoning

  The search page already supports sorting by relevance, rank, and collection count. A date-based sort is useful for discovering
  recently aired anime. As the Bangumi search API only accepts match, heat, rank, and score as sort parameters, the implementation
  fetches results using the default match order and re-sorts them locally by SubjectInfo.airDate.

  Testing

  1. Open the search page
  2. Search for any keyword (e.g. "进击的巨人")
  3. Tap the sort button in the top-right of the results
  4. Select "发布日期"
  5. Verify results are reordered with the most recently aired titles first

  Type of change

  :x: Bug fix (A non-breaking change that fixes an issue)
  :white_check_mark: New feature (A non-breaking change that adds functionality)
  :x: Breaking change (A fix or feature that would cause existing functionality to not work as expected)
  :x: Refactor (A code change that neither fixes a bug nor adds a feature)
  :x: Performance (A code change that improves performance)
  :x: Style (Code style changes)
  :x: Docs (Changes to documentation)
  :x: Chore (Changes to the build process or other tooling)