### PR TITLE
fix(search): use editingQuery instead of presentationFlow in startSea…

### DIFF
--- a/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/search/SuggestionSearchBarState.kt
+++ b/app/shared/ui-exploration/src/commonMain/kotlin/ui/exploration/search/SuggestionSearchBarState.kt
@@ -104,7 +104,7 @@ class SuggestionSearchBarState(
     }
 
     fun startSearch() {
-        val rawQuery = presentationFlow.value.query
+        val rawQuery = editingQuery
         val query = rawQuery.trim()
         val tags = tagsProvider()
         if (query != rawQuery) {


### PR DESCRIPTION
## Description

  Fix search results disappearing when clicking a history item after re-entering the search page.

  Fixes #2914

  ## Reasoning

  `presentationFlow` is derived from `queryFlow` via a coroutine flow with `SharingStarted.WhileSubscribed(5000)`. When a history item is clicked. `setQuery()` and `startSearch()` execute synchronously on the main thread with no coroutine dispatch opportunity between them. As a result, `presentationFlow.value` is always stale when `startSearch()` reads it — it holds `""` even though `queryFlow` has already been updated. This stale empty string is passed to `SearchPageState.startSearch("")`, which overwrites `queryFlow` back to empty and calls `searchState.clear()`, causing results to disappear. Subsequent clicks repeat the same cycle.

  `editingQuery` is a synchronous `mutableStateOf` written directly by
  `setQuery()`, so it always holds the correct value at call time.

  **One-line fix:**
  ```kotlin
  - val rawQuery = presentationFlow.value.query
  + val rawQuery = editingQuery
```


  Testing

  1. Search for any keyword (e.g. "进击的巨人")
  2. Go back to exit the search page
  3. Re-enter the search page
  4. Tap a history item
  5. Verify search results appear correctly
  6. Repeat multiple times to confirm it works consistently

  Type of change

  :white_check_mark: Bug fix (A non-breaking change that fixes an issue)
  :x: New feature (A non-breaking change that adds functionality)
  :x: Breaking change (A fix or feature that would cause existing functionality to not work as expected)
  :x: Refactor (A code change that neither fixes a bug nor adds a feature)
  :x: Performance (A code change that improves performance)
  :x: Style (Code style changes)
  :x: Docs (Changes to documentation)
  :x: Chore (Changes to the build process or other tooling)