### PR TITLE
feat: add local video support

### DIFF
--- a/app/shared/app-data/src/commonMain/kotlin/data/persistent/SettingsStore.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/persistent/SettingsStore.kt
@@ -22,6 +22,7 @@ import me.him188.ani.app.data.repository.SavedWindowState
 import me.him188.ani.app.data.repository.media.MediaSourceSaves
 import me.him188.ani.app.data.repository.media.MediaSourceSubscriptionsSaveData
 import me.him188.ani.app.data.repository.media.MikanIndexes
+import me.him188.ani.app.data.repository.player.EpisodeLocalFileBindings
 import me.him188.ani.app.data.repository.player.EpisodeHistories
 import me.him188.ani.app.data.repository.torrent.peer.PeerFilterSubscriptionsSaveData
 import me.him188.ani.app.data.repository.user.TokenSave
@@ -69,6 +70,17 @@ abstract class PlatformDataStoreManager {
             produceFile = { resolveDataStoreFile("episodeHistories") },
             corruptionHandler = ReplaceFileCorruptionHandler {
                 EpisodeHistories.Empty
+            },
+        )
+    }
+
+    val episodeLocalFileBindingStore by lazy {
+        DataStoreFactory.create(
+            serializer = EpisodeLocalFileBindings.serializer()
+                .asDataStoreSerializer({ EpisodeLocalFileBindings.Empty }),
+            produceFile = { resolveDataStoreFile("episodeLocalFileBindings") },
+            corruptionHandler = ReplaceFileCorruptionHandler {
+                EpisodeLocalFileBindings.Empty
             },
         )
     }

--- a/app/shared/app-data/src/commonMain/kotlin/data/repository/player/EpisodeLocalFileBindingRepository.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/repository/player/EpisodeLocalFileBindingRepository.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.data.repository.player
+
+import androidx.datastore.core.DataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.map
+import kotlinx.serialization.Serializable
+import me.him188.ani.app.data.repository.Repository
+import me.him188.ani.datasources.api.SubtitleKind
+
+@Serializable
+data class EpisodeLocalFileBinding(
+    val subjectId: Int,
+    val episodeId: Int,
+    val filePath: String,
+    val displayName: String,
+    val subtitleLanguageIds: List<String> = emptyList(),
+    val resolution: String = "",
+    val alliance: String = "",
+    val subtitleKind: SubtitleKind? = null,
+)
+
+@Serializable
+data class EpisodeLocalFileBindings(
+    val bindings: List<EpisodeLocalFileBinding> = emptyList(),
+) {
+    companion object {
+        val Empty = EpisodeLocalFileBindings(emptyList())
+    }
+}
+
+interface EpisodeLocalFileBindingRepository {
+    val flow: Flow<List<EpisodeLocalFileBinding>>
+
+    fun bindingFlow(subjectId: Int, episodeId: Int): Flow<EpisodeLocalFileBinding?>
+
+    suspend fun save(binding: EpisodeLocalFileBinding)
+
+    suspend fun remove(subjectId: Int, episodeId: Int): Boolean
+
+    suspend fun get(subjectId: Int, episodeId: Int): EpisodeLocalFileBinding?
+}
+
+class EpisodeLocalFileBindingRepositoryImpl(
+    private val dataStore: DataStore<EpisodeLocalFileBindings>,
+) : Repository(), EpisodeLocalFileBindingRepository {
+    override val flow: Flow<List<EpisodeLocalFileBinding>> = dataStore.data.map { it.bindings }
+
+    override fun bindingFlow(subjectId: Int, episodeId: Int): Flow<EpisodeLocalFileBinding?> {
+        return flow.map { bindings ->
+            bindings.firstOrNull { it.subjectId == subjectId && it.episodeId == episodeId }
+        }
+    }
+
+    override suspend fun save(binding: EpisodeLocalFileBinding) {
+        dataStore.updateData { current ->
+            current.copy(
+                bindings = current.bindings
+                    .filterNot { it.subjectId == binding.subjectId && it.episodeId == binding.episodeId }
+                    .plus(binding),
+            )
+        }
+    }
+
+    override suspend fun remove(subjectId: Int, episodeId: Int): Boolean {
+        var removed = false
+        dataStore.updateData { current ->
+            val filtered = current.bindings.filterNot {
+                val shouldRemove = it.subjectId == subjectId && it.episodeId == episodeId
+                removed = removed || shouldRemove
+                shouldRemove
+            }
+            current.copy(bindings = filtered)
+        }
+        return removed
+    }
+
+    override suspend fun get(subjectId: Int, episodeId: Int): EpisodeLocalFileBinding? {
+        return bindingFlow(subjectId, episodeId).firstOrNull()
+    }
+}

--- a/app/shared/app-data/src/commonMain/kotlin/domain/media/fetch/LocalEpisodeFileBindingMediaSource.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/media/fetch/LocalEpisodeFileBindingMediaSource.kt
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.domain.media.fetch
+
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.io.files.Path
+import me.him188.ani.app.data.repository.player.EpisodeLocalFileBinding
+import me.him188.ani.app.data.repository.player.EpisodeLocalFileBindingRepository
+import me.him188.ani.datasources.api.DefaultMedia
+import me.him188.ani.datasources.api.MediaProperties
+import me.him188.ani.datasources.api.paging.SinglePagePagedSource
+import me.him188.ani.datasources.api.paging.SizedSource
+import me.him188.ani.datasources.api.source.ConnectionStatus
+import me.him188.ani.datasources.api.source.MatchKind
+import me.him188.ani.datasources.api.source.MediaFetchRequest
+import me.him188.ani.datasources.api.source.MediaMatch
+import me.him188.ani.datasources.api.source.MediaSource
+import me.him188.ani.datasources.api.source.MediaSourceInfo
+import me.him188.ani.datasources.api.source.MediaSourceKind
+import me.him188.ani.datasources.api.source.MediaSourceLocation
+import me.him188.ani.datasources.api.topic.EpisodeRange
+import me.him188.ani.datasources.api.topic.FileSize.Companion.bytes
+import me.him188.ani.datasources.api.topic.ResourceLocation
+import me.him188.ani.utils.io.SystemPath
+import me.him188.ani.utils.io.exists
+import me.him188.ani.utils.io.extension
+import me.him188.ani.utils.io.inSystem
+import me.him188.ani.utils.io.isRegularFile
+import me.him188.ani.utils.io.length
+import me.him188.ani.utils.io.name
+
+class LocalEpisodeFileBindingMediaSource(
+    private val repository: EpisodeLocalFileBindingRepository,
+) : MediaSource {
+    override val mediaSourceId: String = ID
+    override val location: MediaSourceLocation = MediaSourceLocation.Local
+    override val kind: MediaSourceKind = MediaSourceKind.LocalCache
+    override val info: MediaSourceInfo = MediaSourceInfo(
+        displayName = "本地绑定",
+        description = "手动绑定到剧集的本地视频文件",
+        isSpecial = true,
+    )
+
+    override suspend fun checkConnection(): ConnectionStatus = ConnectionStatus.SUCCESS
+
+    override suspend fun fetch(query: MediaFetchRequest): SizedSource<MediaMatch> {
+        return SinglePagePagedSource {
+            val subjectId = query.subjectId.toIntOrNull()
+            val episodeId = query.episodeId.toIntOrNull()
+            if (subjectId == null || episodeId == null) {
+                return@SinglePagePagedSource emptyList<MediaMatch>().asFlow()
+            }
+
+            val binding = repository.get(subjectId, episodeId)
+                ?: return@SinglePagePagedSource emptyList<MediaMatch>().asFlow()
+            val file = Path(binding.filePath).inSystem
+            if (!file.exists() || !file.isRegularFile()) {
+                return@SinglePagePagedSource emptyList<MediaMatch>().asFlow()
+            }
+
+            listOf(
+                MediaMatch(
+                    createMedia(binding, query, file),
+                    MatchKind.EXACT,
+                ),
+            ).asFlow()
+        }
+    }
+
+    private fun createMedia(
+        binding: EpisodeLocalFileBinding,
+        query: MediaFetchRequest,
+        file: SystemPath,
+    ): DefaultMedia {
+        val download = ResourceLocation.LocalFile(
+            filePath = binding.filePath,
+            fileType = inferFileType(file),
+        )
+        return DefaultMedia(
+            mediaId = "$ID:${query.subjectId}:${query.episodeId}:${binding.filePath}",
+            mediaSourceId = ID,
+            originalUrl = download.uri,
+            download = download,
+            originalTitle = binding.displayName.ifBlank { file.name },
+            publishedTime = 0L,
+            properties = MediaProperties(
+                subjectName = query.subjectNameCN ?: query.subjectNames.firstOrNull(),
+                episodeName = query.episodeName,
+                subtitleLanguageIds = binding.subtitleLanguageIds,
+                resolution = binding.resolution,
+                alliance = binding.alliance.ifBlank { DEFAULT_ALLIANCE },
+                size = file.length().bytes,
+                subtitleKind = binding.subtitleKind,
+            ),
+            episodeRange = EpisodeRange.single(query.episodeEp ?: query.episodeSort),
+            location = MediaSourceLocation.Local,
+            kind = MediaSourceKind.LocalCache,
+        )
+    }
+
+    private fun inferFileType(file: SystemPath): ResourceLocation.LocalFile.FileType {
+        return when (file.extension.lowercase()) {
+            "ts", "m2ts", "mts" -> ResourceLocation.LocalFile.FileType.MPTS
+            else -> ResourceLocation.LocalFile.FileType.CONTAINED
+        }
+    }
+
+    companion object {
+        const val ID: String = "local-episode-binding"
+        const val DEFAULT_ALLIANCE: String = "本地文件"
+    }
+}

--- a/app/shared/application/src/commonMain/kotlin/platform/CommonKoinModule.kt
+++ b/app/shared/application/src/commonMain/kotlin/platform/CommonKoinModule.kt
@@ -60,6 +60,8 @@ import me.him188.ani.app.data.repository.media.MikanIndexCacheRepositoryImpl
 import me.him188.ani.app.data.repository.media.SelectorMediaSourceEpisodeCacheRepository
 import me.him188.ani.app.data.repository.player.DanmakuRegexFilterRepository
 import me.him188.ani.app.data.repository.player.DanmakuRegexFilterRepositoryImpl
+import me.him188.ani.app.data.repository.player.EpisodeLocalFileBindingRepository
+import me.him188.ani.app.data.repository.player.EpisodeLocalFileBindingRepositoryImpl
 import me.him188.ani.app.data.repository.player.EpisodePlayHistoryRepository
 import me.him188.ani.app.data.repository.player.EpisodePlayHistoryRepositoryImpl
 import me.him188.ani.app.data.repository.player.EpisodeScreenshotRepository
@@ -109,6 +111,7 @@ import me.him188.ani.app.domain.media.cache.engine.TorrentMediaCacheEngine
 import me.him188.ani.app.domain.media.cache.storage.HttpMediaCacheStorage
 import me.him188.ani.app.domain.media.cache.storage.MediaSaveDirProvider
 import me.him188.ani.app.domain.media.cache.storage.TorrentMediaCacheStorage
+import me.him188.ani.app.domain.media.fetch.LocalEpisodeFileBindingMediaSource
 import me.him188.ani.app.domain.media.fetch.MediaSourceManager
 import me.him188.ani.app.domain.media.fetch.MediaSourceManagerImpl
 import me.him188.ani.app.domain.mediasource.codec.MediaSourceCodecManager
@@ -335,6 +338,9 @@ private fun KoinApplication.otherModules(getContext: () -> Context, coroutineSco
     single<EpisodePlayHistoryRepository> {
         EpisodePlayHistoryRepositoryImpl(getContext().dataStores.episodeHistoryStore)
     }
+    single<EpisodeLocalFileBindingRepository> {
+        EpisodeLocalFileBindingRepositoryImpl(getContext().dataStores.episodeLocalFileBindingStore)
+    }
     single<AniSubjectRelationIndexService> {
         val provider = get<AniApiProvider>()
         AniSubjectRelationIndexService(provider.subjectRelationsApi)
@@ -462,10 +468,14 @@ private fun KoinApplication.otherModules(getContext: () -> Context, coroutineSco
     single<MediaSourceCodecManager> {
         MediaSourceCodecManager()
     }
+    single {
+        LocalEpisodeFileBindingMediaSource(get())
+    }
     single<MediaSourceManager> {
         MediaSourceManagerImpl(
             additionalSources = {
-                get<MediaCacheManager>().storagesIncludingDisabled.map { it.cacheMediaSource }
+                listOf(get<LocalEpisodeFileBindingMediaSource>()) +
+                    get<MediaCacheManager>().storagesIncludingDisabled.map { it.cacheMediaSource }
             },
         )
     }

--- a/app/shared/build.gradle.kts
+++ b/app/shared/build.gradle.kts
@@ -129,6 +129,8 @@ kotlin {
         api(libs.coil.svg)
         api(libs.coil.compose.core)
         implementation(libs.constraintlayout.compose)
+        implementation(libs.filekit.dialogs)
+        implementation(libs.filekit.dialogs.compose)
     }
 
     // shared by android and desktop

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodePage.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodePage.kt
@@ -497,6 +497,7 @@ private fun EpisodeScreenTabletVeryWide(
                         0 -> Box(Modifier.fillMaxSize()) {
                             val navigator = LocalNavigator.current
                             val pageState by vm.pageState.collectAsStateWithLifecycle()
+                            val localFileBinding by vm.localFileBindingFlow.collectAsStateWithLifecycle()
                             val toaster = LocalToaster.current
                             pageState?.let { page ->
                                 EpisodeDetails(
@@ -512,6 +513,9 @@ private fun EpisodeScreenTabletVeryWide(
                                     page.mediaSelectorState,
                                     { page.mediaSourceResultListPresentation },
                                     page.selfInfo,
+                                    hasLocalFileBinding = localFileBinding != null,
+                                    onBindLocalFile = { vm.bindLocalFile(it) },
+                                    onClearLocalFileBinding = { vm.clearLocalFileBinding() },
                                     modifier = Modifier.fillMaxSize(),
                                     onSwitchEpisode = { episodeId ->
                                         if (!vm.episodeSelectorState.selectEpisodeId(episodeId)) {
@@ -663,6 +667,7 @@ private fun EpisodeScreenContentPhone(
         episodeDetails = {
             val navigator = LocalNavigator.current
             val pageState by vm.pageState.collectAsStateWithLifecycle()
+            val localFileBinding by vm.localFileBindingFlow.collectAsStateWithLifecycle()
             val scope = rememberCoroutineScope()
 
             pageState?.let { page ->
@@ -679,6 +684,9 @@ private fun EpisodeScreenContentPhone(
                     page.mediaSelectorState,
                     { page.mediaSourceResultListPresentation },
                     page.selfInfo,
+                    hasLocalFileBinding = localFileBinding != null,
+                    onBindLocalFile = { vm.bindLocalFile(it) },
+                    onClearLocalFileBinding = { vm.clearLocalFileBinding() },
                     onSwitchEpisode = { episodeId ->
                         if (!vm.episodeSelectorState.selectEpisodeId(episodeId)) {
                             navigator.navigateEpisodeDetails(vm.subjectId, episodeId)
@@ -1036,6 +1044,7 @@ private fun EpisodeVideo(
                 },
                 mediaSelectorPage = {
                     val pageState by vm.pageState.collectAsStateWithLifecycle()
+                    val localFileBinding by vm.localFileBindingFlow.collectAsStateWithLifecycle()
                     pageState?.let { page ->
                         val (viewKind, onViewKindChange) = rememberSaveable { mutableStateOf(page.initialMediaSelectorViewKind) }
                         EpisodeVideoSideSheets.MediaSelectorSheet(
@@ -1048,6 +1057,9 @@ private fun EpisodeVideo(
                             onDismissRequest = { goBack() },
                             onRefresh = { vm.refreshFetch() },
                             onRestartSource = { vm.restartSource(it) },
+                            hasLocalFileBinding = localFileBinding != null,
+                            onBindLocalFile = { vm.bindLocalFile(it) },
+                            onClearLocalFileBinding = { vm.clearLocalFileBinding() },
                         )
                     }
                 },

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeVideo.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeVideo.kt
@@ -617,6 +617,9 @@ private fun PreviewVideoScaffoldImpl(
                         onDismissRequest = { goBack() },
                         onRefresh = {},
                         onRestartSource = {},
+                        hasLocalFileBinding = false,
+                        onBindLocalFile = { false },
+                        onClearLocalFileBinding = { false },
                     )
                 },
                 episodeSelectorPage = {

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeViewModel.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeViewModel.kt
@@ -59,6 +59,8 @@ import me.him188.ani.app.data.network.AutoSkipRepository
 import me.him188.ani.app.data.repository.episode.EpisodeCollectionRepository
 import me.him188.ani.app.data.repository.episode.EpisodeCommentRepository
 import me.him188.ani.app.data.repository.player.DanmakuRegexFilterRepository
+import me.him188.ani.app.data.repository.player.EpisodeLocalFileBinding
+import me.him188.ani.app.data.repository.player.EpisodeLocalFileBindingRepository
 import me.him188.ani.app.data.repository.subject.SetSubjectCollectionTypeOrDeleteUseCase
 import me.him188.ani.app.data.repository.user.SettingsRepository
 import me.him188.ani.app.domain.comment.PostCommentUseCase
@@ -81,6 +83,7 @@ import me.him188.ani.app.domain.episode.mediaSelectorFlow
 import me.him188.ani.app.domain.foundation.LoadError
 import me.him188.ani.app.domain.media.cache.EpisodeCacheStatus
 import me.him188.ani.app.domain.media.cache.MediaCacheManager
+import me.him188.ani.app.domain.media.fetch.LocalEpisodeFileBindingMediaSource
 import me.him188.ani.app.domain.media.fetch.MediaSourceManager
 import me.him188.ani.app.domain.media.fetch.MediaSourceResultsFilterer
 import me.him188.ani.app.domain.media.resolver.MediaResolver
@@ -157,6 +160,7 @@ import me.him188.ani.danmaku.ui.DanmakuTrackProperties
 import me.him188.ani.datasources.api.PackedDate
 import me.him188.ani.datasources.api.source.MediaFetchRequest
 import me.him188.ani.datasources.api.source.MediaSourceKind
+import me.him188.ani.datasources.api.topic.ResourceLocation
 import me.him188.ani.datasources.api.topic.isDoneOrDropped
 import me.him188.ani.utils.coroutines.SingleTaskExecutor
 import me.him188.ani.utils.coroutines.flows.FlowRestarter
@@ -164,6 +168,11 @@ import me.him188.ani.utils.coroutines.flows.flowOfEmptyList
 import me.him188.ani.utils.coroutines.flows.flowOfNull
 import me.him188.ani.utils.coroutines.flows.restartable
 import me.him188.ani.utils.coroutines.sampleWithInitial
+import me.him188.ani.utils.io.absolutePath
+import me.him188.ani.utils.io.exists
+import me.him188.ani.utils.io.inSystem
+import me.him188.ani.utils.io.isRegularFile
+import me.him188.ani.utils.io.name
 import me.him188.ani.utils.logging.info
 import me.him188.ani.utils.logging.warn
 import me.him188.ani.utils.platform.annotations.TestOnly
@@ -175,6 +184,7 @@ import org.openani.mediamp.MediampPlayer
 import org.openani.mediamp.MediampPlayerFactory
 import org.openani.mediamp.features.chapters
 import org.openani.mediamp.metadata.Chapter
+import kotlinx.io.files.Path
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
@@ -251,6 +261,7 @@ class EpisodeViewModel(
     private val danmakuRegexFilterRepository: DanmakuRegexFilterRepository by inject()
     private val mediaSourceManager: MediaSourceManager by inject()
     private val episodeCommentRepository: EpisodeCommentRepository by inject()
+    private val episodeLocalFileBindingRepository: EpisodeLocalFileBindingRepository by inject()
     private val subjectDetailsStateFactory: SubjectDetailsStateFactory by inject()
     private val setDanmakuEnabledUseCase: SetDanmakuEnabledUseCase by inject()
     private val postCommentUseCase: PostCommentUseCase by inject()
@@ -343,6 +354,11 @@ class EpisodeViewModel(
     @UnsafeEpisodeSessionApi
     private val episodeInfoFlow = episodeCollectionFlow.map { it?.episodeInfo }.distinctUntilChanged()
     // endregion
+
+    @OptIn(UnsafeEpisodeSessionApi::class)
+    val localFileBindingFlow = fetchPlayState.episodeSessionFlow.flatMapLatest { session ->
+        episodeLocalFileBindingRepository.bindingFlow(subjectId, session.episodeId)
+    }.stateIn(backgroundScope, SharingStarted.WhileSubscribed(), null)
 
 
     val playerControllerState = PlayerControllerState(ControllerVisibility.Invisible)
@@ -904,6 +920,63 @@ class EpisodeViewModel(
                 .firstOrNull()
                 ?.restartAll()
         }
+    }
+
+    @OptIn(UnsafeEpisodeSessionApi::class)
+    suspend fun bindLocalFile(filePath: String): Boolean {
+        val file = Path(filePath).inSystem
+        if (!file.exists() || !file.isRegularFile()) {
+            return false
+        }
+
+        val episodeSession = fetchPlayState.episodeSessionFlow.first()
+        val fetchSelect = episodeSession.fetchSelectFlow.firstOrNull() ?: return false
+        val absolutePath = file.absolutePath
+        val selectedMedia = fetchSelect.mediaSelector.selected.value
+            ?: fetchSelect.mediaSelector.preferredCandidatesMedia.first().firstOrNull()
+            ?: fetchSelect.mediaSelector.filteredCandidatesMedia.first().firstOrNull()
+        val properties = selectedMedia?.properties
+
+        episodeLocalFileBindingRepository.save(
+            EpisodeLocalFileBinding(
+                subjectId = subjectId,
+                episodeId = episodeSession.episodeId,
+                filePath = absolutePath,
+                displayName = file.name,
+                subtitleLanguageIds = properties?.subtitleLanguageIds ?: emptyList(),
+                resolution = properties?.resolution ?: "",
+                alliance = properties?.alliance.orEmpty(),
+                subtitleKind = properties?.subtitleKind,
+            ),
+        )
+
+        fetchSelect.mediaFetchSession.restartAll()
+        val localMedia = fetchSelect.mediaSelector.filteredCandidates
+            .mapNotNull { candidates ->
+                candidates.firstNotNullOfOrNull { candidate ->
+                    val media = candidate.result ?: return@firstNotNullOfOrNull null
+                    val download = media.download as? ResourceLocation.LocalFile ?: return@firstNotNullOfOrNull null
+                    if (media.mediaSourceId == LocalEpisodeFileBindingMediaSource.ID && download.filePath == absolutePath) {
+                        media
+                    } else {
+                        null
+                    }
+                }
+            }
+            .first()
+        fetchSelect.mediaSelector.select(localMedia)
+        return true
+    }
+
+    @OptIn(UnsafeEpisodeSessionApi::class)
+    suspend fun clearLocalFileBinding(): Boolean {
+        val episodeSession = fetchPlayState.episodeSessionFlow.first()
+        val removed = episodeLocalFileBindingRepository.remove(subjectId, episodeSession.episodeId)
+        if (!removed) {
+            return false
+        }
+        episodeSession.fetchSelectFlow.firstOrNull()?.mediaFetchSession?.restartAll()
+        return true
     }
 
     /**

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/details/EpisodeDetails.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/details/EpisodeDetails.kt
@@ -142,6 +142,8 @@ import me.him188.ani.app.ui.subject.episode.statistics.DanmakuMatchInfoSummaryRo
 import me.him188.ani.app.ui.subject.episode.statistics.DanmakuStatistics
 import me.him188.ani.app.ui.subject.episode.statistics.VideoStatistics
 import me.him188.ani.app.ui.subject.episode.statistics.createTestDanmakuStatistics
+import me.him188.ani.app.ui.subject.episode.video.sidesheet.LocalVideoActionButtons
+import me.him188.ani.app.ui.subject.episode.video.sidesheet.LocalVideoAvailabilityHint
 import me.him188.ani.app.ui.user.SelfInfoUiState
 import me.him188.ani.app.ui.user.TestSelfInfoUiState
 import me.him188.ani.danmaku.api.DanmakuServiceId
@@ -193,6 +195,9 @@ fun EpisodeDetails(
     mediaSelectorState: MediaSelectorState,
     mediaSourceResultListPresentation: () -> MediaSourceResultListPresentation,
     selfInfo: SelfInfoUiState,
+    hasLocalFileBinding: Boolean,
+    onBindLocalFile: suspend (String) -> Boolean,
+    onClearLocalFileBinding: suspend () -> Boolean,
     onSwitchEpisode: (Int) -> Unit,
     onRefreshMediaSources: () -> Unit,
     onRestartSource: (String) -> Unit,
@@ -369,6 +374,13 @@ fun EpisodeDetails(
                                     containerColor = BottomSheetDefaults.ContainerColor,
                                 ),
                             )
+                            LocalVideoAvailabilityHint(
+                                hasLocalFileBinding = hasLocalFileBinding,
+                                modifier = Modifier
+                                    .padding(horizontal = 16.dp)
+                                    .padding(bottom = 8.dp)
+                                    .fillMaxWidth(),
+                            )
                             MediaSelectorView(
                                 mediaSelectorState,
                                 viewKind,
@@ -382,6 +394,14 @@ fun EpisodeDetails(
                                     .padding(vertical = 12.dp, horizontal = 16.dp)
                                     .fillMaxWidth(),
                                 stickyHeaderBackgroundColor = BottomSheetDefaults.ContainerColor,
+                                topActions = {
+                                    LocalVideoActionButtons(
+                                        hasLocalFileBinding = hasLocalFileBinding,
+                                        onBindLocalFile = onBindLocalFile,
+                                        onClearLocalFileBinding = onClearLocalFileBinding,
+                                        onBindSucceeded = { showMediaSelector = false },
+                                    )
+                                },
                                 onClickItem = {
                                     mediaSelectorState.select(it)
                                     showMediaSelector = false
@@ -403,25 +423,42 @@ fun EpisodeDetails(
                                 .only(WindowInsetsSides.Horizontal + WindowInsetsSides.Top)
                         },
                     ) {
-                        MediaSelectorView(
-                            mediaSelectorState,
-                            viewKind,
-                            onViewKindChange,
-                            fetchRequest,
-                            onFetchRequestChange,
-                            mediaSourceResultListPresentation(),
-                            onRestartSource = onRestartSource,
-                            onRefresh = onRefreshMediaSources,
-                            modifier = Modifier.padding(top = 12.dp)
-                                .padding(horizontal = 16.dp)
-                                .fillMaxWidth(),
-                            stickyHeaderBackgroundColor = BottomSheetDefaults.ContainerColor,
-                            onClickItem = {
-                                mediaSelectorState.select(it)
-                                showMediaSelector = false
-                            },
-                            scrollable = sheetState.targetValue == SheetValue.Expanded,
-                        )
+                        Column {
+                            LocalVideoAvailabilityHint(
+                                hasLocalFileBinding = hasLocalFileBinding,
+                                modifier = Modifier
+                                    .padding(top = 12.dp)
+                                    .padding(horizontal = 16.dp)
+                                    .fillMaxWidth(),
+                            )
+                            MediaSelectorView(
+                                mediaSelectorState,
+                                viewKind,
+                                onViewKindChange,
+                                fetchRequest,
+                                onFetchRequestChange,
+                                mediaSourceResultListPresentation(),
+                                onRestartSource = onRestartSource,
+                                onRefresh = onRefreshMediaSources,
+                                modifier = Modifier.padding(top = 8.dp)
+                                    .padding(horizontal = 16.dp)
+                                    .fillMaxWidth(),
+                                stickyHeaderBackgroundColor = BottomSheetDefaults.ContainerColor,
+                                topActions = {
+                                    LocalVideoActionButtons(
+                                        hasLocalFileBinding = hasLocalFileBinding,
+                                        onBindLocalFile = onBindLocalFile,
+                                        onClearLocalFileBinding = onClearLocalFileBinding,
+                                        onBindSucceeded = { showMediaSelector = false },
+                                    )
+                                },
+                                onClickItem = {
+                                    mediaSelectorState.select(it)
+                                    showMediaSelector = false
+                                },
+                                scrollable = sheetState.targetValue == SheetValue.Expanded,
+                            )
+                        }
                     }
                 }
             }
@@ -1005,6 +1042,9 @@ private fun PreviewEpisodeDetailsImpl(
             mediaSelectorState = mediaSelectorState,
             mediaSourceResultListPresentation = { TestMediaSourceResultListPresentation },
             selfInfo = selfInfo,
+            hasLocalFileBinding = false,
+            onBindLocalFile = { false },
+            onClearLocalFileBinding = { false },
             onSwitchEpisode = {},
             onRefreshMediaSources = {},
             onRestartSource = {},

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/video/sidesheet/EpisodeVideoMediaSelectorSideSheet.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/video/sidesheet/EpisodeVideoMediaSelectorSideSheet.kt
@@ -9,15 +9,20 @@
 
 package me.him188.ani.app.ui.subject.episode.video.sidesheet
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Close
+import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -26,7 +31,13 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
+import io.github.vinceglb.filekit.absolutePath
+import io.github.vinceglb.filekit.dialogs.FileKitType
+import io.github.vinceglb.filekit.dialogs.compose.rememberFilePickerLauncher
+import me.him188.ani.app.ui.foundation.LocalPlatform
 import me.him188.ani.app.ui.foundation.ProvideCompositionLocalsForPreview
+import me.him188.ani.app.ui.foundation.rememberAsyncHandler
+import me.him188.ani.app.ui.foundation.widgets.LocalToaster
 import me.him188.ani.app.ui.mediafetch.MediaSelectorState
 import me.him188.ani.app.ui.mediafetch.MediaSelectorView
 import me.him188.ani.app.ui.mediafetch.MediaSourceResultListPresentation
@@ -39,6 +50,75 @@ import me.him188.ani.app.ui.subject.episode.video.components.EpisodeVideoSideShe
 import me.him188.ani.app.ui.subject.episode.video.settings.SideSheetLayout
 import me.him188.ani.datasources.api.source.MediaFetchRequest
 import me.him188.ani.utils.platform.annotations.TestOnly
+import me.him188.ani.utils.platform.isDesktop
+
+@Composable
+internal fun LocalVideoAvailabilityHint(
+    hasLocalFileBinding: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val text = if (LocalPlatform.current.isDesktop()) {
+        if (hasLocalFileBinding) {
+            "本地视频入口已启用，当前剧集已绑定本地文件。"
+        } else {
+            "本地视频入口已启用，可使用上方按钮手动选择本地视频。"
+        }
+    } else {
+        "本地视频入口未启用：当前平台不是桌面端。"
+    }
+    Text(
+        text = text,
+        modifier = modifier,
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+}
+
+@Composable
+internal fun RowScope.LocalVideoActionButtons(
+    hasLocalFileBinding: Boolean,
+    onBindLocalFile: suspend (String) -> Boolean,
+    onClearLocalFileBinding: suspend () -> Boolean,
+    onBindSucceeded: () -> Unit = {},
+) {
+    if (!LocalPlatform.current.isDesktop()) return
+
+    val asyncHandler = rememberAsyncHandler()
+    val toaster = LocalToaster.current
+    val filePicker = rememberFilePickerLauncher(
+        type = FileKitType.Video,
+        title = "选择本地视频",
+    ) { file ->
+        if (file == null) return@rememberFilePickerLauncher
+        asyncHandler.launch {
+            if (onBindLocalFile(file.absolutePath())) {
+                toaster.toast("已绑定本地视频")
+                onBindSucceeded()
+            } else {
+                toaster.toast("绑定失败，请确认文件存在且当前剧集已加载完成")
+            }
+        }
+    }
+
+    FilledTonalButton(onClick = { filePicker.launch() }) {
+        Text(if (hasLocalFileBinding) "重新绑定" else "使用本地视频")
+    }
+    if (hasLocalFileBinding) {
+        TextButton(
+            onClick = {
+                asyncHandler.launch {
+                    if (onClearLocalFileBinding()) {
+                        toaster.toast("已清除本地绑定")
+                    } else {
+                        toaster.toast("当前剧集没有本地绑定")
+                    }
+                }
+            },
+        ) {
+            Text("清除绑定")
+        }
+    }
+}
 
 @Suppress("UnusedReceiverParameter")
 @Composable
@@ -52,6 +132,9 @@ fun EpisodeVideoSideSheets.MediaSelectorSheet(
     onDismissRequest: () -> Unit,
     onRefresh: () -> Unit,
     onRestartSource: (instanceId: String) -> Unit,
+    hasLocalFileBinding: Boolean,
+    onBindLocalFile: suspend (String) -> Boolean,
+    onClearLocalFileBinding: suspend () -> Boolean,
     modifier: Modifier = Modifier,
 ) {
     SideSheetLayout(
@@ -64,6 +147,14 @@ fun EpisodeVideoSideSheets.MediaSelectorSheet(
             }
         },
     ) {
+        LocalVideoAvailabilityHint(
+            hasLocalFileBinding = hasLocalFileBinding,
+            modifier = Modifier
+                .padding(horizontal = 16.dp)
+                .padding(bottom = 12.dp)
+                .fillMaxWidth(),
+        )
+
         MediaSelectorView(
             mediaSelectorState,
             viewKind,
@@ -77,6 +168,14 @@ fun EpisodeVideoSideSheets.MediaSelectorSheet(
                 .fillMaxWidth()
                 .navigationBarsPadding(),
             stickyHeaderBackgroundColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+            topActions = {
+                LocalVideoActionButtons(
+                    hasLocalFileBinding = hasLocalFileBinding,
+                    onBindLocalFile = onBindLocalFile,
+                    onClearLocalFileBinding = onClearLocalFileBinding,
+                    onBindSucceeded = onDismissRequest,
+                )
+            },
             onClickItem = {
                 mediaSelectorState.select(it)
                 onDismissRequest()
@@ -104,6 +203,9 @@ private fun PreviewEpisodeVideoMediaSelectorSideSheet() {
             onDismissRequest = {},
             onRefresh = {},
             onRestartSource = {},
+            hasLocalFileBinding = false,
+            onBindLocalFile = { false },
+            onClearLocalFileBinding = { false },
         )
     }
 }

--- a/app/shared/ui-mediaselect/src/commonMain/kotlin/ui/mediafetch/MediaSelectorView.kt
+++ b/app/shared/ui-mediaselect/src/commonMain/kotlin/ui/mediafetch/MediaSelectorView.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -118,6 +119,7 @@ fun MediaSelectorView(
     onClickItem: (Media) -> Unit = { state.select(it) },
     singleLineFilter: Boolean = false,
     scrollable: Boolean = true,
+    topActions: @Composable RowScope.() -> Unit = {},
 ) {
     val bringIntoViewRequesters = remember { mutableStateMapOf<Media, BringIntoViewRequester>() }
     val presentation by state.presentationFlow.collectAsStateWithLifecycle()
@@ -145,6 +147,8 @@ fun MediaSelectorView(
             viewKind,
             onViewKindChange,
             onRequestFetchRequestEdit = { showEditRequest = true },
+            showEditRequestButton = fetchRequest != null,
+            topActions = topActions,
             Modifier.fillMaxWidth().padding(bottom = 16.dp),
         )
 
@@ -225,6 +229,8 @@ private fun ViewKindAndMoreRow(
     viewKind: ViewKind,
     onViewKindChange: (ViewKind) -> Unit,
     onRequestFetchRequestEdit: () -> Unit,
+    showEditRequestButton: Boolean,
+    topActions: @Composable RowScope.() -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Row(
@@ -250,21 +256,14 @@ private fun ViewKindAndMoreRow(
             }
         }
 
-        Box {
-            IconButton(onRequestFetchRequestEdit) {
-                Icon(Icons.Rounded.EditSquare, contentDescription = stringResource(Lang.settings_media_source_more))
-            }
-//            DropdownMenu(showDropdown, { showDropdown = false }) {
-//                DropdownMenuItem(
-//                    text = { Text("编辑查询请求") },
-//                    onClick = {
-//                        showEditRequest = true
-//                        showDropdown = false
-//                    },
-//                )
-//            }
+        topActions()
 
-            // 编辑请求
+        if (showEditRequestButton) {
+            Box {
+                IconButton(onRequestFetchRequestEdit) {
+                    Icon(Icons.Rounded.EditSquare, contentDescription = stringResource(Lang.settings_media_source_more))
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
标题：feat: 支持为剧集绑定本地视频文件并持久化复用（桌面端）

变更概述
这个 PR 为剧集播放页增加了“绑定本地视频文件”的能力。
用户在桌面端为某一集手动选择本地视频后，应用会将该绑定关系持久化保存。之后再次进入同一条目/同一剧集时，这个本地文件会作为一个特殊的数据源参与现有的媒体选择与播放流程，用户不需要每次重新手动选择。
这个改动的目标是让“本地已有视频文件”的使用场景能够无缝接入现有播放流程，同时尽量不影响原有的在线数据源选择逻辑。

主要功能
支持为当前剧集手动绑定一个本地视频文件
支持清除当前剧集的本地文件绑定
绑定关系会持久化保存，重启应用后仍然有效
已绑定的本地文件会作为一个特殊媒体源出现在当前剧集的数据源选择流程中
在绑定完成后，会自动刷新媒体列表并优先选中对应的本地文件

实现方式
1. 增加剧集与本地文件的持久化绑定存储
新增了 `EpisodeLocalFileBindingRepository`，用于保存 `(subjectId, episodeId) -> 本地文件路径` 的映射关系。
除了文件路径之外，还会在绑定时尽量复用当前已选媒体的一些属性信息，例如：字幕语言、分辨率、字幕组/联盟信息、字幕类型
这些信息会一起保存，目的是让本地文件在后续作为媒体源参与选择时，仍然能尽量保留原有媒体的展示信息与筛选体验。
绑定数据通过独立的 DataStore 条目持久化保存。

2. 新增本地绑定媒体源
新增了 `LocalEpisodeFileBindingMediaSource`，作为一个特殊媒体源接入现有媒体查询流程。
这个媒体源在查询时会：
根据当前 `subjectId` 和 `episodeId` 查找是否存在本地绑定
检查绑定的文件是否仍然存在、是否为普通文件
如果有效，则构造一个 `ResourceLocation.LocalFile` 类型的媒体项返回
如果文件不存在或无效，则返回空结果
这样做的目的，是把本地文件纳入现有“查询 -> 选择 -> 播放”的统一流程，而不是额外维护一条完全独立的播放分支。

3. 在依赖注入中注册绑定仓库与本地媒体源
在 Koin 模块中注册了新的本地绑定仓库，并将本地绑定媒体源加入媒体源管理流程，使其能参与剧集页面现有的数据源选择逻辑。

4. 在播放页 ViewModel 中接入绑定能力
在 `EpisodeViewModel` 中增加了：
当前剧集本地绑定状态的监听
绑定本地文件的方法
清除本地绑定的方法

绑定流程大致为：
1. 校验用户选择的文件路径是否存在且为普通文件
2. 取当前剧集信息，保存 `(subjectId, episodeId)` 对应的绑定关系
3. 重启当前媒体查询
4. 在刷新后的候选媒体中找到刚刚加入的本地媒体项
5. 自动将其选为当前播放媒体

清除绑定时则会删除当前剧集的绑定记录，并重新触发媒体查询，使界面与候选列表状态保持一致。

 5. 在桌面端媒体选择侧栏提供入口
在媒体选择侧栏中增加了桌面端入口，提供：
使用本地视频
重新绑定
清除绑定
这个入口当前只在桌面平台显示，不在移动端显示。

平台范围
这个功能当前面向桌面平台，UI 开关基于项目内的桌面平台抽象
按当前实现意图，桌面平台包括：
Windows
macOS
Linux

与现有逻辑的关系
 不会替换原有在线数据源逻辑
如果当前剧集没有本地绑定，则行为与现有版本一致
如果本地绑定文件已经不存在，则本地媒体源不会返回可播放结果
本地文件只是作为一个额外的、可选择的特殊媒体源接入现有流程

已知限制 
需要用户自己为每个新视频绑定本地视频，不过如果后续可以考虑增加自动绑定功能

潜在风险
1. 绑定错误视频可能影响弹幕匹配与时间轴对齐
弹幕加载流程会使用当前选中视频的一些信息参与匹配，包括文件名、文件大小以及视频时长。
因此，如果用户为某一集绑定了错误的视频，尤其是在视频时长与实际剧集差异较大时，可能出现弹幕匹配结果不准确
只能通过手动时间校准部分修正，无法完全解决“不同剪辑版本”带来的时间轴差异

当前实现没有针对“错误绑定但文件本身合法”的场景做额外阻止，因为从程序角度它仍然是一个有效的本地媒体文件。

2. 自动相关功能会基于当前实际播放文件的时长工作
例如：自动标记已观看、自动连播下一集、播放进度记忆与恢复
这些逻辑依赖播放器当前返回的视频时长。
因此，如果用户绑定的是错误视频，且视频长度明显不同于目标剧集，可能导致：
自动标记已观看触发时机不准确
自动切换下一集的时机不准确
播放进度恢复行为基于错误文件长度工作
从当前测试看，这类情况更可能表现为逻辑偏差，而不是直接导致程序崩溃。

3. 当前没有对“错误绑定”做内容级校验
这意味着功能设计上默认允许用户显式绑定任意本地视频文件；相应地，错误绑定带来的行为偏差也需要由用户自行承担。

验证情况
我在Windows平台上进行了编译，并绑定了本地视频进行观看，目前弹幕等都是正常的，但是无法验证来自弹弹play是否正常，不过从代码的角度是看应该没有问题

后续可选优化
如果这个方向可以接受，后续我认为还可以继续补充：
在本地绑定文件失效时提供更明确的 UI 提示
在恢复播放进度时增加更严格的边界保护
增加自动绑定等自动化功能
增加对Android平台的支持
