### PR TITLE
feat: add local video support using current logic

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -197,18 +197,18 @@ jobs:
       name: 'Check (Desktop) (Attempt #1)'
       continue-on-error: true
       timeout-minutes: 180
-      run: './gradlew desktopTest "--scan" "-Porg.gradle.daemon.idletimeout=60000" "-Dfile.encoding=UTF-8" "-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake" "-DBoost_INCLUDE_DIR=C:/vcpkg/installed/x64-windows/include" "-Dorg.gradle.jvmargs=-Xmx4g -Dkotlin.daemon.jvm.options=-Xmx4g" "-Dkotlin.daemon.jvm.options=-Xmx4g" "--parallel"'
+      run: './gradlew desktopTest "--scan" "-Porg.gradle.daemon.idletimeout=60000" "-Dfile.encoding=UTF-8" "-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake" "-DBoost_INCLUDE_DIR=C:/vcpkg/installed/x64-windows/include" "-Dorg.gradle.jvmargs=-Xmx4g -Dkotlin.daemon.jvm.options=-Xmx4g" "-Dkotlin.daemon.jvm.options=-Xmx4g" "--parallel" "--no-configuration-cache" "--no-parallel"'
     - id: 'step-24'
       name: 'Check (Desktop) (Attempt #2)'
       continue-on-error: true
       timeout-minutes: 180
-      run: './gradlew desktopTest "--scan" "-Porg.gradle.daemon.idletimeout=60000" "-Dfile.encoding=UTF-8" "-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake" "-DBoost_INCLUDE_DIR=C:/vcpkg/installed/x64-windows/include" "-Dorg.gradle.jvmargs=-Xmx4g -Dkotlin.daemon.jvm.options=-Xmx4g" "-Dkotlin.daemon.jvm.options=-Xmx4g" "--parallel"'
+      run: './gradlew desktopTest "--scan" "-Porg.gradle.daemon.idletimeout=60000" "-Dfile.encoding=UTF-8" "-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake" "-DBoost_INCLUDE_DIR=C:/vcpkg/installed/x64-windows/include" "-Dorg.gradle.jvmargs=-Xmx4g -Dkotlin.daemon.jvm.options=-Xmx4g" "-Dkotlin.daemon.jvm.options=-Xmx4g" "--parallel" "--no-configuration-cache" "--no-parallel"'
       if: '${{ steps.step-23.outcome == ''failure'' }}'
     - id: 'step-25'
       name: 'Check (Desktop) (Attempt #3)'
       continue-on-error: false
       timeout-minutes: 180
-      run: './gradlew desktopTest "--scan" "-Porg.gradle.daemon.idletimeout=60000" "-Dfile.encoding=UTF-8" "-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake" "-DBoost_INCLUDE_DIR=C:/vcpkg/installed/x64-windows/include" "-Dorg.gradle.jvmargs=-Xmx4g -Dkotlin.daemon.jvm.options=-Xmx4g" "-Dkotlin.daemon.jvm.options=-Xmx4g" "--parallel"'
+      run: './gradlew desktopTest "--scan" "-Porg.gradle.daemon.idletimeout=60000" "-Dfile.encoding=UTF-8" "-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake" "-DBoost_INCLUDE_DIR=C:/vcpkg/installed/x64-windows/include" "-Dorg.gradle.jvmargs=-Xmx4g -Dkotlin.daemon.jvm.options=-Xmx4g" "-Dkotlin.daemon.jvm.options=-Xmx4g" "--parallel" "--no-configuration-cache" "--no-parallel"'
       if: '${{ steps.step-24.outcome == ''failure'' }}'
     - id: 'step-26'
       name: 'Check (Android Host) (Attempt #1)'

--- a/.github/workflows/src.main.kts
+++ b/.github/workflows/src.main.kts
@@ -1576,11 +1576,17 @@ class WithMatrix(
 
     fun JobBuilder<*>.gradleCheck() {
         if (matrix.runTests) {
+            val desktopTestGradleArgs = if (matrix.isWindows) {
+                "${matrix.gradleArgs} \"--no-configuration-cache\" \"--no-parallel\""
+            } else {
+                matrix.gradleArgs
+            }
             runGradle(
                 name = "Check (Desktop)",
                 tasks = arrayOf("desktopTest"),
                 maxAttempts = 3,
                 timeoutMinutes = 180,
+                gradleArgs = desktopTestGradleArgs,
             )
             runGradle(
                 name = "Check (Android Host)",

--- a/app/android/src/main/kotlin/AndroidModules.kt
+++ b/app/android/src/main/kotlin/AndroidModules.kt
@@ -28,6 +28,7 @@ import me.him188.ani.app.domain.media.cache.engine.HttpMediaCacheEngine
 import me.him188.ani.app.domain.media.cache.engine.TorrentEngineAccess
 import me.him188.ani.app.domain.media.cache.engine.TorrentMediaCacheEngine
 import me.him188.ani.app.domain.media.cache.storage.MediaSaveDirProvider
+import me.him188.ani.app.domain.episode.PlayerMediaSwitchCooldownConfig
 import me.him188.ani.app.domain.media.fetch.MediaSourceManager
 import me.him188.ani.app.domain.media.resolver.AndroidWebMediaResolver
 import me.him188.ani.app.domain.media.resolver.HttpStreamingMediaResolver
@@ -165,6 +166,7 @@ fun getAndroidModules(
         MediampPlayerSurfaceProviderLoader.register(ExoPlayerMediampPlayerSurfaceProvider())
         MediampPlayerFactoryLoader.first()
     }
+    single { PlayerMediaSwitchCooldownConfig() }
 
     factory<MediaResolver> {
         MediaResolver.from(

--- a/app/desktop/src/main/kotlin/DesktopModules.kt
+++ b/app/desktop/src/main/kotlin/DesktopModules.kt
@@ -25,6 +25,7 @@ import me.him188.ani.app.domain.media.cache.engine.AlwaysUseTorrentEngineAccess
 import me.him188.ani.app.domain.media.cache.engine.HttpMediaCacheEngine
 import me.him188.ani.app.domain.media.cache.engine.TorrentEngineAccess
 import me.him188.ani.app.domain.media.cache.storage.MediaSaveDirProvider
+import me.him188.ani.app.domain.episode.PlayerMediaSwitchCooldownConfig
 import me.him188.ani.app.domain.media.fetch.MediaSourceManager
 import me.him188.ani.app.domain.media.resolver.DesktopWebMediaResolver
 import me.him188.ani.app.domain.media.resolver.HttpStreamingMediaResolver
@@ -59,6 +60,8 @@ import org.openani.mediamp.vlc.VlcMediampPlayerFactory
 import org.openani.mediamp.vlc.compose.VlcMediampPlayerSurfaceProvider
 import java.io.File
 import kotlin.io.path.Path
+
+private const val VLC_MEDIA_SWITCH_COOLDOWN_MILLIS = 400L
 
 fun getDesktopModules(getContext: () -> DesktopContext, scope: CoroutineScope) = module {
     single<TorrentEngineAccess> { AlwaysUseTorrentEngineAccess }
@@ -121,6 +124,10 @@ fun getDesktopModules(getContext: () -> DesktopContext, scope: CoroutineScope) =
         MediampPlayerFactoryLoader.register(VlcMediampPlayerFactory())
         MediampPlayerSurfaceProviderLoader.register(VlcMediampPlayerSurfaceProvider())
         MediampPlayerFactoryLoader.first()
+    }
+    single {
+        // Work around VLC occasionally freezing when media is switched too quickly.
+        PlayerMediaSwitchCooldownConfig(VLC_MEDIA_SWITCH_COOLDOWN_MILLIS)
     }
     single<BrowserNavigator> { DesktopBrowserNavigator() }
     single<WebCaptchaCoordinator> { DesktopWebCaptchaCoordinator(AniDesktopCaptchaTopBar) }

--- a/app/shared/app-data/src/commonMain/kotlin/domain/episode/EpisodeFetchSelectPlayState.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/episode/EpisodeFetchSelectPlayState.kt
@@ -85,6 +85,7 @@ class EpisodeFetchSelectPlayState(
     private val koin: Koin = GlobalKoin,
     private val sharingStarted: SharingStarted = SharingStarted.WhileSubscribed(),
     private val mainDispatcher: CoroutineContext = Dispatchers.Main.immediate,
+    private val playerMediaSwitchCooldownConfig: PlayerMediaSwitchCooldownConfig = PlayerMediaSwitchCooldownConfig(),
     private val analyticsContext: AnalyticsContext = object : AnalyticsContext {},
 ) {
     interface AnalyticsContext {
@@ -105,6 +106,7 @@ class EpisodeFetchSelectPlayState(
         player,
         koin,
         mainDispatcher,
+        playerMediaSwitchCooldownConfig,
     )
 
     private val extensionManager by lazy {

--- a/app/shared/app-data/src/commonMain/kotlin/domain/episode/PlayerMediaSwitchCooldownConfig.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/episode/PlayerMediaSwitchCooldownConfig.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.domain.episode
+
+/**
+ * Compatibility workaround for player kernels that may freeze if a new media is loaded
+ * immediately after [PlayerSession.stopPlayer].
+ */
+class PlayerMediaSwitchCooldownConfig(
+    val delayMillis: Long = 0L,
+) {
+    init {
+        require(delayMillis >= 0) { "delayMillis must be non-negative" }
+    }
+}

--- a/app/shared/app-data/src/commonMain/kotlin/domain/episode/PlayerSession.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/episode/PlayerSession.kt
@@ -12,6 +12,7 @@ package me.him188.ani.app.domain.episode
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -52,6 +53,7 @@ class PlayerSession(
     val player: MediampPlayer,
     koin: Koin,
     private val mainDispatcher: CoroutineContext = Dispatchers.Main.immediate,
+    private val mediaSwitchCooldownConfig: PlayerMediaSwitchCooldownConfig = PlayerMediaSwitchCooldownConfig(),
 ) {
     val mediaResolver: MediaResolver by koin.inject()
 
@@ -72,6 +74,10 @@ class PlayerSession(
         stopPlayer()
         if (media == null) {
             return@coroutineScope
+        }
+        if (mediaSwitchCooldownConfig.delayMillis > 0) {
+            // VLC on desktop may freeze if media is switched immediately after stopPlayback.
+            delay(mediaSwitchCooldownConfig.delayMillis)
         }
 
         try {

--- a/app/shared/app-data/src/commonMain/kotlin/domain/media/cache/ExternalLocalFileMediaFactory.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/media/cache/ExternalLocalFileMediaFactory.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.domain.media.cache
+
+import me.him188.ani.app.data.models.episode.EpisodeInfo
+import me.him188.ani.app.data.models.episode.displayName
+import me.him188.ani.app.data.models.subject.SubjectInfo
+import me.him188.ani.app.data.models.subject.nameCnOrName
+import me.him188.ani.app.domain.media.fetch.create
+import me.him188.ani.datasources.api.DefaultMedia
+import me.him188.ani.datasources.api.Media
+import me.him188.ani.datasources.api.MediaCacheMetadata
+import me.him188.ani.datasources.api.MediaProperties
+import me.him188.ani.datasources.api.source.MediaFetchRequest
+import me.him188.ani.datasources.api.source.MediaSourceKind
+import me.him188.ani.datasources.api.source.MediaSourceLocation
+import me.him188.ani.datasources.api.topic.EpisodeRange
+import me.him188.ani.datasources.api.topic.FileSize.Companion.bytes
+import me.him188.ani.datasources.api.topic.ResourceLocation
+import me.him188.ani.utils.io.SystemPath
+import me.him188.ani.utils.io.absolutePath
+import me.him188.ani.utils.io.length
+import me.him188.ani.utils.io.name
+
+object ExternalLocalFileMediaFactory {
+    fun createMedia(
+        file: SystemPath,
+        subjectInfo: SubjectInfo,
+        episodeInfo: EpisodeInfo,
+    ): Media {
+        val filePath = file.absolutePath
+        return DefaultMedia(
+            mediaId = "external-local-file:${subjectInfo.subjectId}:${episodeInfo.episodeId}:${filePath.hashCode()}",
+            mediaSourceId = MediaCacheManager.LOCAL_FS_MEDIA_SOURCE_ID,
+            originalUrl = filePath,
+            download = ResourceLocation.LocalFile(
+                filePath = filePath,
+                fileType = ResourceLocation.LocalFile.FileType.CONTAINED,
+            ),
+            originalTitle = file.name,
+            publishedTime = 0L,
+            properties = MediaProperties(
+                subjectName = subjectInfo.nameCnOrName,
+                episodeName = episodeInfo.displayName,
+                subtitleLanguageIds = emptyList(),
+                resolution = "",
+                alliance = "外部文件",
+                size = file.length().bytes,
+                subtitleKind = null,
+            ),
+            episodeRange = EpisodeRange.single(episodeInfo.sort),
+            location = MediaSourceLocation.Local,
+            kind = MediaSourceKind.LocalCache,
+        )
+    }
+
+    fun createMetadata(
+        subjectInfo: SubjectInfo,
+        episodeInfo: EpisodeInfo,
+    ): MediaCacheMetadata {
+        return MediaCacheMetadata(
+            MediaFetchRequest.create(subjectInfo, episodeInfo),
+        )
+    }
+}

--- a/app/shared/app-data/src/commonMain/kotlin/domain/media/cache/engine/MediaCacheEngine.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/media/cache/engine/MediaCacheEngine.kt
@@ -107,5 +107,6 @@ value class MediaCacheEngineKey(val key: String) {
     companion object {
         val Anitorrent = MediaCacheEngineKey(TorrentEngineType.Anitorrent.id)
         val WebM3u = MediaCacheEngineKey("web-m3u")
+        val ExternalLocalFile = MediaCacheEngineKey("external-local-file")
     }
 }

--- a/app/shared/app-data/src/commonMain/kotlin/domain/media/cache/requester/EpisodeCacheRequester.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/media/cache/requester/EpisodeCacheRequester.kt
@@ -61,6 +61,16 @@ interface EpisodeCacheRequester {
      * 取消当前请求. 若没有请求则不做任何事情.
      */
     suspend fun cancelRequest()
+
+    /**
+     * 使用已选定的 [Media] 直接创建缓存请求.
+     *
+     * 适用于不需要查询远端资源列表的场景, 例如用户手动选择本地文件.
+     */
+    suspend fun requestSelectedMedia(
+        request: EpisodeCacheRequest,
+        media: Media,
+    ): CacheRequestStage.Done
 }
 
 /**
@@ -296,6 +306,33 @@ class EpisodeCacheRequesterImpl(
     override suspend fun cancelRequest() {
         stageLock.withLock {
             cancelRequestLocked(CacheRequestStage.Idle)
+        }
+    }
+
+    override suspend fun requestSelectedMedia(
+        request: EpisodeCacheRequest,
+        media: Media,
+    ): CacheRequestStage.Done {
+        stageLock.withLock {
+            val current = stage.value
+            current.close()
+
+            val storages = storagesLazy.first().filter { it.engine.supports(media) }
+            check(storages.isNotEmpty()) { "No media cache storage supports media: $media" }
+            check(storages.size == 1) {
+                "Selected media requires ambiguous storage selection: media=$media, storages=${storages.map { it.mediaSourceId }}"
+            }
+
+            return CacheRequestStage.Done(
+                request = request,
+                media = media,
+                storage = storages.single(),
+                metadata = MediaCacheMetadata(
+                    MediaFetchRequest.Companion.create(request.subjectInfo, request.episodeInfo),
+                ),
+            ).also {
+                stage.value = it
+            }
         }
     }
 

--- a/app/shared/app-data/src/commonMain/kotlin/domain/media/cache/storage/ExternalLocalFileMediaCacheStorage.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/media/cache/storage/ExternalLocalFileMediaCacheStorage.kt
@@ -1,0 +1,217 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.domain.media.cache.storage
+
+import androidx.datastore.core.DataStore
+import kotlinx.collections.immutable.minus
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import kotlinx.io.files.Path
+import me.him188.ani.app.domain.media.cache.LocalFileMediaCache
+import me.him188.ani.app.domain.media.cache.MediaCache
+import me.him188.ani.app.domain.media.cache.engine.MediaCacheEngine
+import me.him188.ani.app.domain.media.cache.engine.MediaCacheEngineKey
+import me.him188.ani.app.domain.media.cache.engine.MediaStats
+import me.him188.ani.app.domain.media.resolver.EpisodeMetadata
+import me.him188.ani.datasources.api.CachedMedia
+import me.him188.ani.datasources.api.Media
+import me.him188.ani.datasources.api.MediaCacheMetadata
+import me.him188.ani.datasources.api.topic.ResourceLocation
+import me.him188.ani.utils.coroutines.IO_
+import me.him188.ani.utils.coroutines.update
+import me.him188.ani.utils.io.inSystem
+import me.him188.ani.utils.io.isRegularFile
+import me.him188.ani.utils.io.exists
+import me.him188.ani.utils.logging.error
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+
+class ExternalLocalFileMediaCacheStorage(
+    override val mediaSourceId: String,
+    private val store: DataStore<List<MediaCacheSave>>,
+    parentCoroutineContext: CoroutineContext = EmptyCoroutineContext,
+) : AbstractDataStoreMediaCacheStorage(
+    mediaSourceId = mediaSourceId,
+    datastore = store,
+    engine = ExternalLocalFileMediaCacheEngine(mediaSourceId),
+    displayName = "LocalFile",
+    parentCoroutineContext = parentCoroutineContext,
+) {
+    private val lock = Mutex()
+
+    override suspend fun restorePersistedCaches() {
+        lock.withLock {
+            cleanupInvalidBindings()
+            refreshCache()
+        }
+    }
+
+    override suspend fun restoreFile(
+        origin: Media,
+        metadata: MediaCacheMetadata,
+        reportRecovered: suspend (MediaCache) -> Unit,
+    ): MediaCache? = withContext(Dispatchers.IO_) {
+        try {
+            super.restoreFile(origin, metadata, reportRecovered)
+        } catch (e: Exception) {
+            logger.error(e) { "Failed to restore external local file cache for ${origin.mediaId}" }
+            null
+        }
+    }
+
+    override suspend fun cache(
+        media: Media,
+        metadata: MediaCacheMetadata,
+        episodeMetadata: EpisodeMetadata,
+        resume: Boolean,
+    ): MediaCache {
+        return lock.withLock {
+            listFlow.value.firstOrNull { isSameMediaAndEpisode(it, media, metadata) }?.let { return it }
+
+            if (!engine.supports(media)) {
+                throw UnsupportedOperationException("Engine does not support media: $media")
+            }
+
+            val previousBinding = listFlow.value.firstOrNull {
+                it.metadata.subjectId == metadata.subjectId && it.metadata.episodeId == metadata.episodeId
+            }
+            if (previousBinding != null) {
+                removeCache(previousBinding)
+            }
+
+            val cache = engine.createCache(
+                media,
+                metadata,
+                episodeMetadata,
+                scope.coroutineContext,
+            )
+
+            withContext(Dispatchers.IO_) {
+                store.updateData { list ->
+                    list.filterNot {
+                        it.engine == engine.engineKey &&
+                                it.metadata.subjectId == metadata.subjectId &&
+                                it.metadata.episodeId == metadata.episodeId
+                    } + MediaCacheSave(cache.origin, cache.metadata, engine.engineKey)
+                }
+            }
+
+            listFlow.update { plus(cache) }
+
+            if (resume) {
+                cache.resume()
+            }
+
+            cache
+        }
+    }
+
+    override suspend fun deleteFirst(predicate: (MediaCache) -> Boolean): Boolean {
+        return lock.withLock {
+            val cache = listFlow.value.firstOrNull(predicate) ?: return false
+            removeCache(cache)
+        }
+    }
+
+    private suspend fun cleanupInvalidBindings() {
+        val invalidMediaIds = metadataFlow.first()
+            .filter { !isValidLocalFile(it.origin) }
+            .map { it.origin.mediaId }
+            .toSet()
+
+        if (invalidMediaIds.isEmpty()) {
+            return
+        }
+
+        withContext(Dispatchers.IO_) {
+            store.updateData { list ->
+                list.filterNot {
+                    it.engine == engine.engineKey && it.origin.mediaId in invalidMediaIds
+                }
+            }
+        }
+    }
+
+    private suspend fun removeCache(cache: MediaCache): Boolean {
+        listFlow.update { minus(cache) }
+        restoredLocalFileMediaCacheIds.update { minus(cache.origin.mediaId) }
+        withContext(Dispatchers.IO_) {
+            store.updateData { list ->
+                list.filterNot { isSameMediaAndEpisode(cache, it) }
+            }
+        }
+        cache.closeAndDeleteFiles()
+        return true
+    }
+
+    private fun isValidLocalFile(origin: Media): Boolean {
+        val file = (origin.download as? ResourceLocation.LocalFile)
+            ?.filePath
+            ?.let(::Path)
+            ?.inSystem
+            ?: return false
+        return file.exists() && file.isRegularFile()
+    }
+
+    private class ExternalLocalFileMediaCacheEngine(
+        private val mediaSourceId: String,
+    ) : MediaCacheEngine {
+        override val engineKey: MediaCacheEngineKey = MediaCacheEngineKey.ExternalLocalFile
+        override val stats: Flow<MediaStats> = flowOf(MediaStats.Zero)
+
+        override fun supports(media: Media): Boolean {
+            return media !is CachedMedia && media.download is ResourceLocation.LocalFile
+        }
+
+        override suspend fun restore(
+            origin: Media,
+            metadata: MediaCacheMetadata,
+            parentContext: CoroutineContext,
+        ): MediaCache? {
+            return createBindingOrNull(origin, metadata)
+        }
+
+        override suspend fun createCache(
+            origin: Media,
+            metadata: MediaCacheMetadata,
+            episodeMetadata: EpisodeMetadata,
+            parentContext: CoroutineContext,
+        ): MediaCache {
+            return createBindingOrNull(origin, metadata)
+                ?: error("External local file cache only supports existing local files: ${origin.download}")
+        }
+
+        override suspend fun deleteUnusedCaches(all: List<MediaCache>) {
+        }
+
+        private fun createBindingOrNull(origin: Media, metadata: MediaCacheMetadata): LocalFileMediaCache? {
+            val file = (origin.download as? ResourceLocation.LocalFile)
+                ?.filePath
+                ?.let(::Path)
+                ?.inSystem
+                ?: return null
+            if (!file.exists() || !file.isRegularFile()) {
+                return null
+            }
+            return LocalFileMediaCache(
+                origin = origin,
+                metadata = metadata,
+                file = file,
+                backedMediaSourceId = mediaSourceId,
+                onCloseAndDeleteFiles = { _ -> },
+            )
+        }
+    }
+}

--- a/app/shared/app-data/src/commonTest/kotlin/domain/media/cache/requester/EpisodeCacheRequesterTest.kt
+++ b/app/shared/app-data/src/commonTest/kotlin/domain/media/cache/requester/EpisodeCacheRequesterTest.kt
@@ -211,6 +211,32 @@ class EpisodeCacheRequesterTest {
     }
 
     @Test
+    fun `requestSelectedMedia goes directly to Done`() = runTest {
+        val request = createRequest()
+        val media = createTestDefaultMedia(
+            mediaId = "local-file-1",
+            mediaSourceId = "local-file-system",
+            originalTitle = "local-file-1.mkv",
+            download = ResourceLocation.LocalFile(nullFilePath),
+            originalUrl = nullFilePath,
+            publishedTime = 1L,
+            properties = createTestMediaProperties(
+                subjectName = "Test Subject",
+                episodeName = "Episode 1",
+            ),
+            episodeRange = EpisodeRange.single(EpisodeSort(1)),
+            location = MediaSourceLocation.Local,
+            kind = MediaSourceKind.LocalCache,
+        )
+
+        val done = requester.requestSelectedMedia(request, media)
+
+        assertIs<CacheRequestStage.Done>(requester.stage.value)
+        assertSame(media, done.media)
+        assertSame(storage, done.storage)
+    }
+
+    @Test
     fun `done has correct metadata`() = runTest {
         val request = createRequest().run {
             copy(

--- a/app/shared/app-data/src/commonTest/kotlin/domain/media/cache/storage/ExternalLocalFileMediaCacheStorageTest.kt
+++ b/app/shared/app-data/src/commonTest/kotlin/domain/media/cache/storage/ExternalLocalFileMediaCacheStorageTest.kt
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.domain.media.cache.storage
+
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import me.him188.ani.app.data.models.episode.EpisodeInfo
+import me.him188.ani.app.data.models.subject.SubjectInfo
+import me.him188.ani.app.data.persistent.MemoryDataStore
+import me.him188.ani.app.domain.media.cache.ExternalLocalFileMediaFactory
+import me.him188.ani.app.domain.media.cache.engine.MediaCacheEngineKey
+import me.him188.ani.app.domain.media.resolver.toEpisodeMetadata
+import me.him188.ani.datasources.api.EpisodeSort
+import me.him188.ani.datasources.api.EpisodeType
+import me.him188.ani.datasources.api.topic.ResourceLocation
+import me.him188.ani.utils.io.SystemPaths
+import me.him188.ani.utils.io.absolutePath
+import me.him188.ani.utils.io.createTempFile
+import me.him188.ani.utils.io.delete
+import me.him188.ani.utils.io.exists
+import me.him188.ani.utils.io.writeText
+import kotlin.coroutines.CoroutineContext
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ExternalLocalFileMediaCacheStorageTest {
+    @Test
+    fun `delete should not remove original file`() = runTest {
+        val storage = createStorage(backgroundScope.coroutineContext)
+        val file = SystemPaths.createTempFile(prefix = "external-local-file", suffix = ".mkv").apply {
+            writeText("test-data")
+        }
+        val subjectInfo = SubjectInfo.Empty.copy(subjectId = 1, name = "Test Subject")
+        val episodeInfo = EpisodeInfo(1, EpisodeType.MainStory, sort = EpisodeSort(1), name = "Episode 1")
+
+        val cache = storage.cache(
+            media = ExternalLocalFileMediaFactory.createMedia(file, subjectInfo, episodeInfo),
+            metadata = ExternalLocalFileMediaFactory.createMetadata(subjectInfo, episodeInfo),
+            episodeMetadata = episodeInfo.toEpisodeMetadata(),
+            resume = false,
+        )
+
+        storage.delete(cache)
+
+        assertTrue(file.exists())
+        assertEquals(0, storage.listFlow.first().size)
+    }
+
+    @Test
+    fun `cache should replace previous binding for same episode`() = runTest {
+        val storage = createStorage(backgroundScope.coroutineContext)
+        val subjectInfo = SubjectInfo.Empty.copy(subjectId = 1, name = "Test Subject")
+        val episodeInfo = EpisodeInfo(1, EpisodeType.MainStory, sort = EpisodeSort(1), name = "Episode 1")
+        val file1 = SystemPaths.createTempFile(prefix = "external-local-file-1", suffix = ".mkv").apply {
+            writeText("test-data-1")
+        }
+        val file2 = SystemPaths.createTempFile(prefix = "external-local-file-2", suffix = ".mkv").apply {
+            writeText("test-data-2")
+        }
+
+        storage.cache(
+            media = ExternalLocalFileMediaFactory.createMedia(file1, subjectInfo, episodeInfo),
+            metadata = ExternalLocalFileMediaFactory.createMetadata(subjectInfo, episodeInfo),
+            episodeMetadata = episodeInfo.toEpisodeMetadata(),
+            resume = false,
+        )
+        storage.cache(
+            media = ExternalLocalFileMediaFactory.createMedia(file2, subjectInfo, episodeInfo),
+            metadata = ExternalLocalFileMediaFactory.createMetadata(subjectInfo, episodeInfo),
+            episodeMetadata = episodeInfo.toEpisodeMetadata(),
+            resume = false,
+        )
+
+        val bindings = storage.listFlow.first()
+        val cachedMedia = bindings.single().getCachedMedia()
+
+        assertEquals(1, bindings.size)
+        assertEquals(file2.absolutePath, cachedMedia.download.let { it as ResourceLocation.LocalFile }.filePath)
+        assertTrue(file1.exists())
+        assertTrue(file2.exists())
+    }
+
+    @Test
+    fun `restorePersistedCaches should drop missing file metadata`() = runTest {
+        val store = MemoryDataStore<List<MediaCacheSave>>(emptyList())
+        val storage = ExternalLocalFileMediaCacheStorage(
+            mediaSourceId = "local-file-system",
+            store = store,
+            parentCoroutineContext = backgroundScope.coroutineContext,
+        )
+        val subjectInfo = SubjectInfo.Empty.copy(subjectId = 1, name = "Test Subject")
+        val episodeInfo = EpisodeInfo(1, EpisodeType.MainStory, sort = EpisodeSort(1), name = "Episode 1")
+        val missingFile = SystemPaths.createTempFile(prefix = "external-local-missing", suffix = ".mkv").apply {
+            writeText("missing")
+            delete()
+        }
+        val media = ExternalLocalFileMediaFactory.createMedia(missingFile, subjectInfo, episodeInfo)
+
+        store.data.value = listOf(
+            MediaCacheSave(
+                origin = media,
+                metadata = ExternalLocalFileMediaFactory.createMetadata(subjectInfo, episodeInfo),
+                engine = MediaCacheEngineKey.ExternalLocalFile,
+            ),
+        )
+
+        storage.restorePersistedCaches()
+
+        assertEquals(0, storage.listFlow.first().size)
+        assertEquals(0, store.data.first().size)
+    }
+
+    private fun createStorage(parentCoroutineContext: CoroutineContext): ExternalLocalFileMediaCacheStorage {
+        return ExternalLocalFileMediaCacheStorage(
+            mediaSourceId = "local-file-system",
+            store = MemoryDataStore(emptyList()),
+            parentCoroutineContext = parentCoroutineContext,
+        )
+    }
+}

--- a/app/shared/application/src/commonMain/kotlin/platform/CommonKoinModule.kt
+++ b/app/shared/application/src/commonMain/kotlin/platform/CommonKoinModule.kt
@@ -106,6 +106,7 @@ import me.him188.ani.app.domain.media.cache.engine.HttpMediaCacheEngine
 import me.him188.ani.app.domain.media.cache.engine.KtorPersistentHttpDownloader
 import me.him188.ani.app.domain.media.cache.engine.MediaCacheEngineKey
 import me.him188.ani.app.domain.media.cache.engine.TorrentMediaCacheEngine
+import me.him188.ani.app.domain.media.cache.storage.ExternalLocalFileMediaCacheStorage
 import me.him188.ani.app.domain.media.cache.storage.HttpMediaCacheStorage
 import me.him188.ani.app.domain.media.cache.storage.MediaSaveDirProvider
 import me.him188.ani.app.domain.media.cache.storage.TorrentMediaCacheStorage
@@ -401,13 +402,21 @@ private fun KoinApplication.otherModules(getContext: () -> Context, coroutineSco
     }
 
     // Media
+    single {
+        ExternalLocalFileMediaCacheStorage(
+            mediaSourceId = MediaCacheManager.LOCAL_FS_MEDIA_SOURCE_ID,
+            store = getContext().dataStores.mediaCacheMetadataStore,
+            parentCoroutineContext = coroutineScope.childScopeContext(),
+        )
+    }
     single<MediaCacheManager> {
         val id = MediaCacheManager.LOCAL_FS_MEDIA_SOURCE_ID
         val engines = get<TorrentManager>().engines
         val metadataStore = getContext().dataStores.mediaCacheMetadataStore
 
         MediaCacheManagerImpl(
-            storagesIncludingDisabled = buildList(capacity = engines.size) {
+            storagesIncludingDisabled = buildList(capacity = engines.size + 1) {
+                add(get<ExternalLocalFileMediaCacheStorage>())
                 /*if (currentAniBuildConfig.isDebug) {
                     // 注意, 这个必须要在第一个, 见 [DefaultTorrentManager.engines] 注释
                     add(

--- a/app/shared/application/src/iosMain/kotlin/ios/AniIos.kt
+++ b/app/shared/application/src/iosMain/kotlin/ios/AniIos.kt
@@ -39,6 +39,7 @@ import me.him188.ani.app.domain.media.cache.engine.AlwaysUseTorrentEngineAccess
 import me.him188.ani.app.domain.media.cache.engine.HttpMediaCacheEngine
 import me.him188.ani.app.domain.media.cache.engine.TorrentEngineAccess
 import me.him188.ani.app.domain.media.cache.storage.MediaSaveDirProvider
+import me.him188.ani.app.domain.episode.PlayerMediaSwitchCooldownConfig
 import me.him188.ani.app.domain.media.fetch.MediaSourceManager
 import me.him188.ani.app.domain.media.resolver.HttpStreamingMediaResolver
 import me.him188.ani.app.domain.media.resolver.IosWebMediaResolver
@@ -290,6 +291,7 @@ fun getIosModules(
     single<MediampPlayerFactory<*>> {
         AVKitMediampPlayerFactory()
     }
+    single { PlayerMediaSwitchCooldownConfig() }
     single<MediaSaveDirProvider> {
         object : MediaSaveDirProvider {
             override val saveDir: String

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeViewModel.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeViewModel.kt
@@ -68,6 +68,7 @@ import me.him188.ani.app.domain.danmaku.SetDanmakuEnabledUseCase
 import me.him188.ani.app.domain.episode.EpisodeCompletionContext.isKnownCompleted
 import me.him188.ani.app.domain.episode.EpisodeDanmakuLoader
 import me.him188.ani.app.domain.episode.EpisodeFetchSelectPlayState
+import me.him188.ani.app.domain.episode.PlayerMediaSwitchCooldownConfig
 import me.him188.ani.app.domain.episode.EpisodeSession
 import me.him188.ani.app.domain.episode.GetSubjectRecommendationUseCase
 import me.him188.ani.app.domain.episode.SetEpisodeCollectionTypeUseCase
@@ -264,6 +265,7 @@ class EpisodeViewModel(
     private val setSubjectCollectionTypeOrDeleteUseCase: SetSubjectCollectionTypeOrDeleteUseCase by inject()
     private val getPreferredWebMediaSource: GetPreferredWebMediaSourceUseCase by inject()
     private val webCaptchaCoordinator: WebCaptchaCoordinator by inject()
+    private val playerMediaSwitchCooldownConfig: PlayerMediaSwitchCooldownConfig by inject()
     // endregion
 
     private val tasker = SingleTaskExecutor(backgroundScope.coroutineContext)
@@ -304,6 +306,7 @@ class EpisodeViewModel(
         ),
         koin,
         sharingStarted = SharingStarted.WhileSubscribed(5_000),
+        playerMediaSwitchCooldownConfig = playerMediaSwitchCooldownConfig,
         analyticsContext = object : EpisodeFetchSelectPlayState.AnalyticsContext {
             override suspend fun isFullscreen(): Boolean? {
                 return withContext(Dispatchers.Main) { this@EpisodeViewModel.isFullscreen }

--- a/app/shared/ui-cache/build.gradle.kts
+++ b/app/shared/ui-cache/build.gradle.kts
@@ -28,6 +28,8 @@ kotlin {
         api(projects.app.shared.uiAdaptive)
         api(projects.app.shared.uiSettings)
         api(projects.app.shared.uiMediaselect)
+        implementation(libs.filekit.dialogs)
+        implementation(libs.filekit.dialogs.compose)
         implementation(libs.compose.components.resources)
         implementation(projects.app.shared.placeholder)
     }

--- a/app/shared/ui-cache/build.gradle.kts
+++ b/app/shared/ui-cache/build.gradle.kts
@@ -24,6 +24,7 @@ kotlin {
         namespace = "me.him188.ani.app.ui.cache"
     }
     sourceSets.commonMain.dependencies {
+        api(projects.app.shared.appData)
         api(projects.app.shared.uiFoundation)
         api(projects.app.shared.uiAdaptive)
         api(projects.app.shared.uiSettings)

--- a/app/shared/ui-cache/src/commonMain/kotlin/ui/cache/CacheManagementScreen.kt
+++ b/app/shared/ui-cache/src/commonMain/kotlin/ui/cache/CacheManagementScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.material.icons.filled.SelectAll
 import androidx.compose.material.icons.rounded.Close
 import androidx.compose.material.icons.rounded.Delete
 import androidx.compose.material.icons.rounded.Info
+import androidx.compose.material.icons.rounded.VideoFile
 import androidx.compose.material.icons.rounded.MoreVert
 import androidx.compose.material.icons.rounded.Pause
 import androidx.compose.material.icons.rounded.PlayArrow
@@ -812,6 +813,7 @@ private fun CacheListItem(
 private fun renderEngineIcon(key: MediaCacheEngineKey) = when (key) {
     MediaCacheEngineKey.Anitorrent -> Icons.Filled.P2p to "BT"
     MediaCacheEngineKey.WebM3u -> Icons.Filled.Language to "Web"
+    MediaCacheEngineKey.ExternalLocalFile -> Icons.Rounded.VideoFile to "本地文件"
     else -> Icons.AutoMirrored.Rounded.HelpOutline to "未知"
 }
 

--- a/app/shared/ui-cache/src/commonMain/kotlin/ui/cache/components/CacheFilterAndSortBar.kt
+++ b/app/shared/ui-cache/src/commonMain/kotlin/ui/cache/components/CacheFilterAndSortBar.kt
@@ -368,5 +368,6 @@ private fun renderCollectionType(type: UnifiedCollectionType): String {
 private fun renderEngineKey(key: MediaCacheEngineKey): String = when (key) {
     MediaCacheEngineKey.Anitorrent -> "BT"
     MediaCacheEngineKey.WebM3u -> "Web"
+    MediaCacheEngineKey.ExternalLocalFile -> "本地文件"
     else -> key.key
 }

--- a/app/shared/ui-cache/src/commonMain/kotlin/ui/cache/subject/CacheListGroup.kt
+++ b/app/shared/ui-cache/src/commonMain/kotlin/ui/cache/subject/CacheListGroup.kt
@@ -30,6 +30,7 @@ import androidx.compose.material.icons.rounded.Close
 import androidx.compose.material.icons.rounded.Delete
 import androidx.compose.material.icons.rounded.Download
 import androidx.compose.material.icons.rounded.DownloadDone
+import androidx.compose.material.icons.rounded.VideoFile
 import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
@@ -62,6 +63,9 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.fastForEachIndexed
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import io.github.vinceglb.filekit.dialogs.FileKitType
+import io.github.vinceglb.filekit.dialogs.compose.rememberFilePickerLauncher
+import io.github.vinceglb.filekit.path
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -76,6 +80,8 @@ import me.him188.ani.app.domain.media.fetch.restart
 import me.him188.ani.app.platform.LocalContext
 import me.him188.ani.app.platform.PermissionManager
 import me.him188.ani.app.tools.getOrZero
+import me.him188.ani.app.ui.foundation.LocalPlatform
+import me.him188.ani.app.ui.foundation.rememberAsyncHandler
 import me.him188.ani.app.ui.foundation.layout.desktopTitleBar
 import me.him188.ani.app.ui.foundation.layout.desktopTitleBarPadding
 import me.him188.ani.app.ui.foundation.theme.stronglyWeaken
@@ -91,6 +97,7 @@ import me.him188.ani.app.ui.settings.framework.components.TextItem
 import me.him188.ani.datasources.api.EpisodeSort
 import me.him188.ani.datasources.api.topic.UnifiedCollectionType
 import me.him188.ani.datasources.api.topic.isDoneOrDropped
+import me.him188.ani.utils.platform.isDesktop
 import org.koin.mp.KoinPlatform
 
 
@@ -247,6 +254,7 @@ fun SettingsScope.EpisodeCacheListGroup(
                     }
                 },
                 isRequestHidden = hideMediaSelector,
+                onBindLocalFile = { state.bindLocalFile(episodeCacheState, it) },
                 dropdown = {
                     ItemDropdown(
                         showDropdown = showDropdown,
@@ -308,10 +316,24 @@ fun SettingsScope.EpisodeCacheItem(
     episode: EpisodeCacheState,
     onClick: () -> Unit,
     isRequestHidden: Boolean,
+    onBindLocalFile: (String) -> Unit = {},
     modifier: Modifier = Modifier,
     dropdown: @Composable () -> Unit = {},
 ) {
     val colorByWatchStatus = contentColorForWatchStatus(episode.info.watchStatus, episode.info.hasPublished)
+    val showProgressIndicator = episode.showProgressIndicator.collectAsStateWithLifecycle().value
+    val hasActionRunning = episode.actionTasker.isRunning.collectAsStateWithLifecycle().value
+    val asyncHandler = rememberAsyncHandler()
+    val filePicker = rememberFilePickerLauncher(
+        type = FileKitType.Video,
+        title = "选择本地视频",
+    ) { file ->
+        file?.let {
+            asyncHandler.launch {
+                onBindLocalFile(it.path)
+            }
+        }
+    }
     TextItem(
         icon = {
             CompositionLocalProvider(LocalContentColor provides colorByWatchStatus) {
@@ -322,9 +344,12 @@ fun SettingsScope.EpisodeCacheItem(
             dropdown()
 
             CompositionLocalProvider(LocalContentColor provides colorByWatchStatus) {
-                EpisodeCacheActionIcon(
-                    isLoadingIndefinitely = !isRequestHidden && episode.showProgressIndicator.collectAsStateWithLifecycle().value,
-                    hasActionRunning = episode.actionTasker.isRunning.collectAsStateWithLifecycle().value,
+                EpisodeCacheActionButtons(
+                    showBindLocalButton = LocalPlatform.current.isDesktop(),
+                    canBindLocalFile = episode.cacheStatus == EpisodeCacheStatus.NotCached,
+                    onBindLocalFile = { filePicker.launch() },
+                    isLoadingIndefinitely = !isRequestHidden && showProgressIndicator,
+                    hasActionRunning = hasActionRunning,
                     cacheStatus = episode.cacheStatus,
                     canCache = episode.canCache,
                     onClick = onClick,
@@ -369,6 +394,39 @@ fun contentColorForWatchStatus(
     } else {
         LocalContentColor.current
     }
+
+@Composable
+fun EpisodeCacheActionButtons(
+    showBindLocalButton: Boolean,
+    canBindLocalFile: Boolean,
+    onBindLocalFile: () -> Unit,
+    isLoadingIndefinitely: Boolean,
+    hasActionRunning: Boolean,
+    cacheStatus: EpisodeCacheStatus?,
+    canCache: Boolean,
+    onClick: () -> Unit,
+    onCancel: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(modifier, verticalAlignment = Alignment.CenterVertically) {
+        if (showBindLocalButton) {
+            IconButton(
+                onClick = onBindLocalFile,
+                enabled = canBindLocalFile && !isLoadingIndefinitely && !hasActionRunning,
+            ) {
+                Icon(Icons.Rounded.VideoFile, "绑定本地视频")
+            }
+        }
+        EpisodeCacheActionIcon(
+            isLoadingIndefinitely = isLoadingIndefinitely,
+            hasActionRunning = hasActionRunning,
+            cacheStatus = cacheStatus,
+            canCache = canCache,
+            onClick = onClick,
+            onCancel = onCancel,
+        )
+    }
+}
 
 @Composable
 fun EpisodeCacheActionIcon(

--- a/app/shared/ui-cache/src/commonMain/kotlin/ui/cache/subject/EpisodeCacheListState.kt
+++ b/app/shared/ui-cache/src/commonMain/kotlin/ui/cache/subject/EpisodeCacheListState.kt
@@ -70,6 +70,8 @@ interface EpisodeCacheListState {
      * 删除一个剧集的现有缓存.
      */
     fun deleteCache(episode: EpisodeCacheState)
+
+    fun bindLocalFile(episode: EpisodeCacheState, path: String)
 }
 
 /**
@@ -99,6 +101,7 @@ class EpisodeCacheListStateImpl(
     private val onRequestCache: suspend (episode: EpisodeCacheState, autoSelectByCached: Boolean) -> CacheRequestStage?,
     private val onRequestCacheComplete: suspend (episode: EpisodeCacheTargetInfo) -> Unit,
     private val onDeleteCache: suspend (episode: EpisodeCacheState) -> Unit,
+    private val onBindLocalFile: suspend (episode: EpisodeCacheState, path: String) -> CacheRequestStage.Done,
 ) : EpisodeCacheListState {
     override val episodes: List<EpisodeCacheState> by episodes
 
@@ -220,6 +223,20 @@ class EpisodeCacheListStateImpl(
                 throw e
                 // errorMessage.value = ErrorMessage.simple("删除缓存失败", e)
             }
+        }
+    }
+
+    override fun bindLocalFile(episode: EpisodeCacheState, path: String) {
+        if (episode.actionTasker.isRunning.value) return
+        episode.actionTasker.launch {
+            currentEpisode
+                ?.takeIf { it !== episode }
+                ?.cacheRequester
+                ?.cancelRequest()
+            callComplete(
+                episode,
+                onBindLocalFile(episode, path),
+            )
         }
     }
 }

--- a/app/shared/ui-cache/src/commonMain/kotlin/ui/cache/subject/SubjectCacheScene.kt
+++ b/app/shared/ui-cache/src/commonMain/kotlin/ui/cache/subject/SubjectCacheScene.kt
@@ -28,6 +28,7 @@ import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
+import kotlinx.io.files.Path
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
@@ -52,6 +53,7 @@ import me.him188.ani.app.data.repository.user.SettingsRepository
 import me.him188.ani.app.domain.danmaku.DanmakuRepository
 import me.him188.ani.app.domain.episode.EpisodeCompletionContext.isKnownCompleted
 import me.him188.ani.app.domain.media.cache.DeleteCacheByEpisodeIdUseCase
+import me.him188.ani.app.domain.media.cache.ExternalLocalFileMediaFactory
 import me.him188.ani.app.domain.media.cache.MediaCache
 import me.him188.ani.app.domain.media.cache.MediaCacheManager
 import me.him188.ani.app.domain.media.cache.requester.CacheRequestStage
@@ -80,6 +82,9 @@ import me.him188.ani.utils.analytics.AnalyticsEvent.Companion.CacheCreate
 import me.him188.ani.utils.analytics.recordEvent
 import me.him188.ani.utils.coroutines.flows.combine
 import me.him188.ani.utils.coroutines.retryWithBackoffDelay
+import me.him188.ani.utils.io.exists
+import me.him188.ani.utils.io.inSystem
+import me.him188.ani.utils.io.isRegularFile
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import kotlin.time.Duration
@@ -214,13 +219,33 @@ class SubjectCacheViewModelImpl(
                     when (target.media.kind) {
                         MediaSourceKind.WEB -> "web"
                         MediaSourceKind.BitTorrent -> "bt"
-                        MediaSourceKind.LocalCache -> null // impossible
+                        MediaSourceKind.LocalCache -> "local"
                     },
                 )
             }
         },
         onDeleteCache = { episode ->
             deleteCacheByEpisodeIdUseCase(subjectId, episode.episodeId)
+        },
+        onBindLocalFile = { episode, path ->
+            val file = Path(path).inSystem
+            check(file.exists() && file.isRegularFile()) {
+                "Local file does not exist or is not a regular file: $path"
+            }
+
+            val subjectInfo = subjectInfoFlow.first().subjectInfo
+            val episodeInfo = episodeCollectionsFlow.first().firstOrNull { it.episodeId == episode.episodeId }?.episodeInfo
+                ?: error(
+                    "Episode ${episode.episodeId} not found from episodes: ${
+                        episodeCollectionsFlow.first().joinToString { it.episodeId.toString() }
+                    }",
+                )
+            val request = EpisodeCacheRequest(subjectInfo, episodeInfo)
+
+            episode.cacheRequester.requestSelectedMedia(
+                request = request,
+                media = ExternalLocalFileMediaFactory.createMedia(file, subjectInfo, episodeInfo),
+            )
         },
     )
     override val mediaSourceInfoProvider: MediaSourceInfoProvider = MediaSourceInfoProvider(

--- a/app/shared/ui-cache/src/commonTest/kotlin/ui/cache/subject/EpisodeCacheListStateTest.kt
+++ b/app/shared/ui-cache/src/commonTest/kotlin/ui/cache/subject/EpisodeCacheListStateTest.kt
@@ -59,6 +59,7 @@ class EpisodeCacheListStateTest {
             },
             onRequestCacheComplete = {},
             onDeleteCache = {},
+            onBindLocalFile = { _, _ -> error("not used") },
         )
 
         state.requestCache(episode1, autoSelectCached = false)

--- a/danmaku/api/build.gradle.kts
+++ b/danmaku/api/build.gradle.kts
@@ -33,4 +33,9 @@ kotlin {
             implementation(libs.kotlinx.coroutines.test)
         }
     }
+    sourceSets.desktopTest {
+        dependencies {
+            runtimeOnly(libs.slf4j.simple)
+        }
+    }
 }

--- a/danmaku/api/src/commonMain/kotlin/DanmakuCollection.kt
+++ b/danmaku/api/src/commonMain/kotlin/DanmakuCollection.kt
@@ -83,7 +83,7 @@ class TimeBasedDanmakuSession private constructor(
     override val totalCount: Flow<Int?> = listFlow.map { it.size }
 
     companion object {
-        private val logger = logger<TimeBasedDanmakuSession>()
+        private val logger by lazy { logger<TimeBasedDanmakuSession>() }
 
         fun create(
             listFlow: Flow<List<DanmakuInfo>>,


### PR DESCRIPTION
## 概述

这个 PR 主要做了两件事：

1. 增加“使用本地视频”的能力，允许将用户手动选择的本地视频文件直接绑定到剧集，复用现有缓存体系进行管理和播放。
2. 为桌面端播放器切换增加冷却时间，规避 VLC 在快速切换视频时偶现的卡死或崩溃问题。

## 背景

现有缓存链路主要围绕远端媒体展开，用户即使已经有本地视频文件，也无法直接接入现有的剧集缓存、播放和管理流程。

另外，桌面端在切换视频时，如果在 `stopPlayer` 之后立刻加载新媒体，VLC 有概率出现卡死或崩溃，影响连续播放和切换体验。

## 技术路线

本次实现没有单独新开一套“本地视频播放”逻辑，而是选择复用现有的媒体缓存模型和播放链路，把“外部本地文件”抽象成一种特殊的本地缓存媒体。

这样做的原因是：

- 可以复用已有的剧集-媒体绑定关系
- 可以直接接入现有缓存管理页、状态流转和播放入口
- 可以避免为本地文件额外维护一套平行的数据结构
- 后续如果需要扩展本地文件相关能力，也可以继续沿用现有缓存体系

播放器切换问题则采用配置化冷却时间的方式处理，在播放器真正加载下一条媒体前增加一个平台可配置的等待时间，尽量将兼容性处理收敛在播放会话内部，而不是散落到上层业务逻辑里。

## 实现方式

### 1. 本地视频能力

#### 1.1 将外部文件包装为可播放媒体
新增 `ExternalLocalFileMediaFactory`，将用户选择的本地文件构造成 `Media`：

- `download` 使用 `ResourceLocation.LocalFile`
- `mediaSourceId` 复用 `local-file-system`
- `kind` 标记为 `LocalCache`
- 同时生成对应的 `MediaCacheMetadata`

这样本地文件可以直接进入现有的媒体解析、缓存和播放流程。

#### 1.2 新增外部本地文件缓存存储
新增 `ExternalLocalFileMediaCacheStorage`，为“外部本地文件绑定”提供单独的存储实现，并注册新的 `MediaCacheEngineKey.ExternalLocalFile`。

核心行为如下：

- 不拷贝、不移动原始文件，只保存“剧集 <-> 本地文件路径”的绑定关系
- 绑定同一剧集的新文件时，替换旧绑定
- 删除缓存时只删除绑定关系，不删除用户原文件
- 应用恢复时校验本地文件是否仍存在
- 如果文件已不存在，则自动清理失效元数据

这部分实现尽量贴近原有缓存逻辑，避免引入新的生命周期模型。

#### 1.3 让缓存请求支持“直接使用已选媒体”
在 `EpisodeCacheRequester` 中新增 `requestSelectedMedia`，用于跳过“拉取远端资源列表 -> 选择资源”这一步，直接基于用户已经选定的 `Media` 进入 `Done` 阶段。

这使得本地文件场景可以复用现有缓存完成逻辑，而不需要伪造远端请求流程。

#### 1.4 桌面端增加绑定入口
在缓存管理界面中，为桌面端剧集项增加“绑定本地视频”按钮：

- 使用文件选择器选择本地视频文件
- 校验文件存在且为普通文件
- 根据当前条目的 `subjectInfo` 和 `episodeInfo` 创建本地媒体
- 通过 `requestSelectedMedia` 直接生成缓存请求
- 在缓存列表和筛选项中展示“本地文件”类型及对应图标

## 2. VLC 切换冷却时间

新增 `PlayerMediaSwitchCooldownConfig`，并在 `PlayerSession` 中接入：

- 在停止当前播放器后、加载下一条媒体前，根据配置执行 `delay`
- 将该兼容性策略封装在播放会话层，对上层业务透明

平台配置如下：

- Desktop: 注入 `400ms` 冷却时间
- Android: 注入默认值 `0ms`
- iOS: 注入默认值 `0ms`

也就是说，只有桌面端启用了这次兼容性等待，移动端行为保持不变。

## 平台适用范围

### 本地视频绑定功能
当前用户可见入口只在 **Desktop** 开放。

适用平台：

- Desktop（Windows / macOS / Linux 桌面端）

说明：

- UI 上通过桌面端文件选择器选择视频文件
- 缓存管理页新增“绑定本地视频”按钮也只在桌面端展示

对于 Android / iOS：

- 本次没有开放对应的用户入口
- 相关公共层能力已接入共享缓存体系，但当前不是面向移动端交付的功能

### VLC 切换冷却时间
当前实际生效平台为 **Desktop**。

说明：

- 桌面端注入 `400ms`，用于规避 VLC 快速切换媒体时的卡死/崩溃问题
- Android / iOS 注入默认 `0ms`，不改变原有行为

<img width="610" height="1496" alt="屏幕截图 2026-04-18 181224" src="https://github.com/user-attachments/assets/b3b0d126-fa88-442c-8cfe-31ffaff31868" />
<img width="2287" height="1496" alt="屏幕截图 2026-04-18 181303" src="https://github.com/user-attachments/assets/acd2c32c-3af2-4f26-a7e3-1a79f54c0907" />
<img width="2457" height="1548" alt="image" src="https://github.com/user-attachments/assets/b89aa858-daec-4268-8a3b-d7cb5a05ae00" />
