### PR TITLE
fix(player): allow seeking after playback finishes

### DIFF
--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodePage.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodePage.kt
@@ -886,7 +886,7 @@ private fun EpisodeVideo(
             // not yet supported
         },
         onPreviewFinished = {
-            vm.player.seekTo(it)
+            vm.seekTo(it)
         },
     )
     val scope = rememberCoroutineScope()

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeViewModel.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeViewModel.kt
@@ -173,6 +173,7 @@ import org.koin.core.component.inject
 import org.openani.mediamp.InternalMediampApi
 import org.openani.mediamp.MediampPlayer
 import org.openani.mediamp.MediampPlayerFactory
+import org.openani.mediamp.PlaybackState
 import org.openani.mediamp.features.chapters
 import org.openani.mediamp.metadata.Chapter
 import kotlin.time.Duration.Companion.milliseconds
@@ -706,7 +707,7 @@ class EpisodeViewModel(
         chapters = combinedChaptersFlow.produceState(emptyList()),
         onSkip = {
             launchInBackground(Dispatchers.Main) {
-                player.seekTo(it)
+                seekTo(it)
             }
         },
         videoLength = player.mediaProperties.mapNotNull { it?.durationMillis?.milliseconds }
@@ -903,6 +904,20 @@ class EpisodeViewModel(
                 .filterNotNull()
                 .firstOrNull()
                 ?.restartAll()
+        }
+    }
+
+    fun seekTo(positionMillis: Long) {
+        val unlockFinished = player.playbackState.value == PlaybackState.FINISHED &&
+                !videoScaffoldConfig.autoPlayNext
+        if (unlockFinished) {
+            // Unlock mediamp's `< READY` guard on seekTo/resume. TODO: drop when mediamp#29 lands.
+            @Suppress("UNCHECKED_CAST")
+            (player.playbackState as MutableStateFlow<PlaybackState>).value = PlaybackState.PAUSED
+        }
+        player.seekTo(positionMillis)
+        if (unlockFinished) {
+            player.resume()
         }
     }
 


### PR DESCRIPTION
### Description

Fix: after a video finishes playing, dragging the progress bar has no effect.

Fixes #2971

### Reasoning

mediamp 0.1.8 guards `seekTo()` and `resume()` with `if (playbackState < READY) return` in all three backends (Exo/VLC/AVKit). Since `FINISHED(3) < READY(4)` ordinal-wise, user seeks are silently dropped after natural playback end.

Fix (animeko-local, no mediamp change needed):

- Introduce `EpisodeViewModel.seekTo(...)` as the single user-seek entry point (progress bar + chapter skip now both route through it).
- When state is `FINISHED` **and** auto-play-next is off, briefly rewrite `playbackState` to `PAUSED` via `MutableStateFlow` cast to unlock the guard, then run normal `seekTo + resume`. ExoPlayer's `STATE_ENDED` natively accepts seek, so no source re-prepare, no UI flash.
- `!autoPlayNext` gate avoids racing with `SwitchNextEpisodeExtension` during the transient FINISHED window right before episode switch.
- All three backends' state listeners have `<= FINISHED` early-return guards, so the external PAUSED write is not clobbered before our seek lands.

Upstream tracking: https://github.com/open-ani/mediamp/issues/29 — once mediamp relaxes the guard, drop the whole branch.

### Testing

1. Disable auto-play-next. Play a video to completion → drag the progress bar to an earlier position → video should resume from that position.
2. Disable auto-play-next. Play to completion → tap OP/ED skip button → should jump and resume.
3. Enable auto-play-next. Play to completion → verify the next episode is loaded normally (hack is skipped).
4. Normal seeking during playback / pause is unchanged.

### Type of change

:white_check_mark: **Bug fix** (A non-breaking change that fixes an issue)
:x: **New feature** (A non-breaking change that adds functionality)
:x: **Breaking change** (A fix or feature that would cause existing functionality to not work as expected)
:x: **Refactor** (A code change that neither fixes a bug nor adds a feature)
:x: **Performance** (A code change that improves performance)
:x: **Style** (Code style changes)
:x: **Docs** (Changes to documentation)
:x: **Chore** (Changes to the build process or other tooling)