### PR TITLE
Fix auto-next-episode incorrectly triggering again when first media source fails after switching

### DIFF
--- a/app/shared/app-data/src/commonMain/kotlin/domain/player/extension/SwitchNextEpisodeExtension.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/player/extension/SwitchNextEpisodeExtension.kt
@@ -60,21 +60,20 @@ class SwitchNextEpisodeExtension(
 
     private suspend fun impl(session: EpisodeSession): Nothing {
         val player = context.player
-        var hasStartedPlaying = false
-        player.playbackState.collect { playback ->
-            if (playback == PlaybackState.READY || playback == PlaybackState.PLAYING) {
-                hasStartedPlaying = true
-            }
+        var previous: PlaybackState? = null
+        player.playbackState.collect { current ->
+            if (previous == PlaybackState.PLAYING && current == PlaybackState.FINISHED) {
+                val closeToEnd = player.mediaProperties.value.let { prop ->
+                    prop != null && prop.durationMillis > 0L && prop.durationMillis - player.currentPositionMillis.value < 5000
+                }
 
-            val closeToEnd = player.mediaProperties.value.let { prop ->
-                prop != null && prop.durationMillis > 0L && prop.durationMillis - player.currentPositionMillis.value < 5000
+                if (closeToEnd) {
+                    val nextEpisode = getNextEpisode(session.episodeId)
+                    logger.info("播放完毕，切换下一集 $nextEpisode")
+                    context.switchEpisode(nextEpisode ?: return@collect)
+                }
             }
-
-            if (playback == PlaybackState.FINISHED && closeToEnd && hasStartedPlaying) {
-                val nextEpisode = getNextEpisode(session.episodeId)
-                logger.info("播放完毕，切换下一集 $nextEpisode")
-                context.switchEpisode(nextEpisode ?: return@collect)
-            }
+            previous = current
         }
     }
 

--- a/app/shared/app-data/src/commonMain/kotlin/domain/player/extension/SwitchNextEpisodeExtension.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/domain/player/extension/SwitchNextEpisodeExtension.kt
@@ -60,12 +60,17 @@ class SwitchNextEpisodeExtension(
 
     private suspend fun impl(session: EpisodeSession): Nothing {
         val player = context.player
+        var hasStartedPlaying = false
         player.playbackState.collect { playback ->
+            if (playback == PlaybackState.READY || playback == PlaybackState.PLAYING) {
+                hasStartedPlaying = true
+            }
+
             val closeToEnd = player.mediaProperties.value.let { prop ->
                 prop != null && prop.durationMillis > 0L && prop.durationMillis - player.currentPositionMillis.value < 5000
             }
 
-            if (playback == PlaybackState.FINISHED && closeToEnd) {
+            if (playback == PlaybackState.FINISHED && closeToEnd && hasStartedPlaying) {
                 val nextEpisode = getNextEpisode(session.episodeId)
                 logger.info("播放完毕，切换下一集 $nextEpisode")
                 context.switchEpisode(nextEpisode ?: return@collect)

--- a/app/shared/app-data/src/commonTest/kotlin/domain/episode/EpisodePlayerTestSuite.kt
+++ b/app/shared/app-data/src/commonTest/kotlin/domain/episode/EpisodePlayerTestSuite.kt
@@ -100,7 +100,7 @@ class EpisodePlayerTestSuite(
 fun TestScope.createExceptionCapturingSupervisorScope(parentScope: CoroutineScope = backgroundScope): Pair<CoroutineScope, CompletableDeferred<Throwable>> {
     val backgroundException = CompletableDeferred<Throwable>()
     val scope = CoroutineScope(
-        SupervisorJob(parentScope.coroutineContext[Job]) + CoroutineExceptionHandler { _, throwable ->
+        (parentScope.coroutineContext.minusKey(Job)) + SupervisorJob(parentScope.coroutineContext[Job]) + CoroutineExceptionHandler { _, throwable ->
             backgroundException.complete(throwable)
         },
     )

--- a/app/shared/app-data/src/commonTest/kotlin/domain/player/extension/SwitchNextEpisodeExtensionTest.kt
+++ b/app/shared/app-data/src/commonTest/kotlin/domain/player/extension/SwitchNextEpisodeExtensionTest.kt
@@ -30,12 +30,17 @@ import me.him188.ani.app.domain.episode.createExceptionCapturingSupervisorScope
 import me.him188.ani.app.domain.episode.getCurrentEpisodeId
 import me.him188.ani.app.domain.episode.mediaSelectorFlow
 import me.him188.ani.app.domain.media.TestMediaList
+import me.him188.ani.app.domain.media.player.data.MediaDataProvider
+import me.him188.ani.app.domain.media.resolver.EpisodeMetadata
 import me.him188.ani.app.domain.media.resolver.MediaResolver
 import me.him188.ani.app.domain.media.resolver.TestUniversalMediaResolver
+import me.him188.ani.app.domain.media.resolver.UnsupportedMediaException
 import me.him188.ani.app.domain.player.ExtensionException
 import me.him188.ani.app.domain.settings.GetVideoScaffoldConfigUseCase
+import me.him188.ani.datasources.api.Media
 import me.him188.ani.utils.coroutines.childScope
 import org.openani.mediamp.PlaybackState
+import org.openani.mediamp.metadata.MediaProperties
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -63,12 +68,15 @@ class SwitchNextEpisodeExtensionTest : AbstractPlayerExtensionTest() {
         }
     }
 
-    private fun TestScope.createCase(getNextEpisode: suspend (currentEpisodeId: Int) -> Int?) = run {
+    private fun TestScope.createCase(
+        getNextEpisode: suspend (currentEpisodeId: Int) -> Int?,
+        resolver: MediaResolver = TestUniversalMediaResolver,
+    ) = run {
         Dispatchers.setMain(StandardTestDispatcher(testScheduler))
         val testScope = this.childScope()
         val suite = EpisodePlayerTestSuite(this, testScope)
         suite.enableAutoPlayNext()
-        suite.registerComponent<MediaResolver> { TestUniversalMediaResolver }
+        suite.registerComponent<MediaResolver> { resolver }
 
         val state = suite.createState(
             listOf(
@@ -208,5 +216,61 @@ class SwitchNextEpisodeExtensionTest : AbstractPlayerExtensionTest() {
             assertIs<RepositoryNetworkException>(cause)
         }
         scope.cancel()
+    }
+
+    @Test
+    fun `does not switch next episode when playback never started after switching`() = runTest {
+        var getNextEpisodeCalled = 0
+        val failingResolver = object : MediaResolver {
+            override fun supports(media: Media): Boolean = true
+            override suspend fun resolve(media: Media, episode: EpisodeMetadata): MediaDataProvider<*> =
+                throw UnsupportedMediaException(media)
+        }
+        val (testScope, suite, state) =
+            createCase(
+                getNextEpisode = {
+                    getNextEpisodeCalled++
+                    1000
+                },
+                resolver = failingResolver,
+            )
+
+        loadSelectedMedia(suite, state)
+
+        assertEquals(initialEpisodeId, state.getCurrentEpisodeId())
+        assertEquals(0, getNextEpisodeCalled)
+
+        // 播到最尾部了，触发自动切集
+        suite.player.seekTo(suite.player.mediaProperties.value!!.durationMillis)
+        suite.player.playbackState.value = PlaybackState.PLAYING
+        advanceUntilIdle()
+        suite.player.playbackState.value = PlaybackState.FINISHED
+        advanceUntilIdle()
+
+        // Verify switched to next episode (1000)
+        assertEquals(1000, state.getCurrentEpisodeId())
+        assertEquals(1, getNextEpisodeCalled)
+
+        // Trigger media selection for new episode to load (and fail) and broadcast MediaLoadedEvent
+        state.mediaSelectorFlow.filterNotNull().first().select(TestMediaList[0])
+        advanceUntilIdle()
+
+        // Simulate production player state where mediaProperties is not cleared
+        // after stopPlayback and playbackState remains FINISHED.
+        suite.player.mediaProperties.value = MediaProperties(
+            durationMillis = 100_000,
+        )
+        suite.player.seekTo(100_000)
+        // Toggle playbackState to trigger a FINISHED evaluation while hasStartedPlaying is false
+        suite.player.playbackState.value = PlaybackState.CREATED
+        advanceUntilIdle()
+        suite.player.playbackState.value = PlaybackState.FINISHED
+        advanceUntilIdle()
+
+        // Verify does NOT switch again
+        assertEquals(1000, state.getCurrentEpisodeId())
+        assertEquals(1, getNextEpisodeCalled)
+
+        testScope.cancel()
     }
 }


### PR DESCRIPTION
## What                                                                                                                                                                                                                                                                                                              
Added a hasStartedPlaying guard in SwitchNextEpisodeExtension so that auto-switch to the next episode only happens when the current episode has actually reached `PLAYING` or `READY`. Also added a regression test and fixed `createExceptionCapturingSupervisorScope` to preserve the parent test dispatcher.
                                                                                                                                                                                                                                                                                                                    
## Where           
  - app/shared/app-data/src/commonMain/kotlin/domain/player/extension/SwitchNextEpisodeExtension.kt                                                                                                                                                                                                                 
  - app/shared/app-data/src/commonTest/kotlin/domain/player/extension/SwitchNextEpisodeExtensionTest.kt                                                                                                                                                                                                             
  - app/shared/app-data/src/commonTest/kotlin/domain/episode/EpisodePlayerTestSuite.kt                 
                                                                                                                                                                                                                                                                                                                    
## Why                                                                                                                                                                                                                                                                                                               
  When `auto-play-next` is enabled and the user finishes an episode, the app switches to the next episode. If the first media source of the new episode fails to load, `PlayerSession.loadMedia()` calls `stopPlayback()`, which leaves `playbackState` as `FINISHED` and may retain stale `mediaProperties` from the previous episode. `SwitchNextEpisodeExtension` then misinterprets this `FINISHED` state as "current episode completed" and incorrectly triggers another switch. The `hasStartedPlaying` flag ensures we only react to `FINISHED` if the current session has actually started playback.

## Related

fixed #2975