### PR TITLE
feat(collection): add client-side sort-by-name toggle

### DIFF
--- a/app/shared/app-data/src/commonMain/kotlin/data/models/preference/UISettings.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/models/preference/UISettings.kt
@@ -87,6 +87,7 @@ data class LegacyThemeSettings(
 @Immutable
 data class MyCollectionsSettings(
     val enableListAnimation1: Boolean = true,
+    val sortByName: Boolean = false,
 ) {
     companion object {
         @Stable

--- a/app/shared/app-data/src/commonTest/kotlin/data/models/preference/MyCollectionsSettingsTest.kt
+++ b/app/shared/app-data/src/commonTest/kotlin/data/models/preference/MyCollectionsSettingsTest.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.data.models.preference
+
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+class MyCollectionsSettingsTest {
+    @Test
+    fun `default sortByName is false preserves old behavior`() {
+        assertFalse(MyCollectionsSettings.Default.sortByName)
+    }
+
+    @Test
+    fun `old JSON without sortByName deserializes with default false`() {
+        val oldJson = """{"enableListAnimation1":true}"""
+        val parsed = Json { ignoreUnknownKeys = true }
+            .decodeFromString(MyCollectionsSettings.serializer(), oldJson)
+        assertEquals(true, parsed.enableListAnimation1)
+        assertFalse(parsed.sortByName)
+    }
+}

--- a/app/shared/src/commonMain/kotlin/ui/main/MainScreen.kt
+++ b/app/shared/src/commonMain/kotlin/ui/main/MainScreen.kt
@@ -283,6 +283,8 @@ private fun MainScreenContent(
                             },
                             modifier = Modifier.fillMaxSize(),
                             enableAnimation = userCollectionsViewModel.myCollectionsSettings.enableListAnimation1,
+                            sortByName = userCollectionsViewModel.myCollectionsSettings.sortByName,
+                            onToggleSortByName = { coroutineScope.launch { userCollectionsViewModel.toggleSortByName() } },
                         )
                     }
 

--- a/app/shared/ui-subject/src/commonMain/kotlin/ui/subject/collection/CollectionPage.kt
+++ b/app/shared/ui-subject/src/commonMain/kotlin/ui/subject/collection/CollectionPage.kt
@@ -42,8 +42,11 @@ import androidx.compose.material.icons.rounded.HowToReg
 import androidx.compose.material.icons.rounded.Refresh
 import androidx.compose.material.icons.rounded.Search
 import androidx.compose.material.icons.rounded.Settings
+import androidx.compose.material.icons.rounded.Sort
+import androidx.compose.material.icons.rounded.SortByAlpha
 import androidx.compose.material.icons.rounded.Sync
 import androidx.compose.material3.Badge
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.Button
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
@@ -227,8 +230,9 @@ fun CollectionPage(
     actions: @Composable RowScope.() -> Unit = {},
     windowInsets: WindowInsets = AniWindowInsets.forPageContent(),
     enableAnimation: Boolean = true,
-
-    ) {
+    sortByName: Boolean = false,
+    onToggleSortByName: () -> Unit = {},
+) {
     val scope = rememberCoroutineScope()
     var hideBangumiSync by rememberSaveable { mutableStateOf(false) }
     val isBangumiSyncing = fullSyncState != null && !fullSyncState.finished
@@ -264,6 +268,13 @@ fun CollectionPage(
                         modifier = Modifier.rotate(angle),
                     )
                 }
+            }
+            IconButton(onClick = onToggleSortByName) {
+                Icon(
+                    imageVector = if (sortByName) Icons.Rounded.SortByAlpha else Icons.Rounded.Sort,
+                    contentDescription = if (sortByName) "取消按名称排序" else "按名称排序",
+                    tint = if (sortByName) MaterialTheme.colorScheme.primary else LocalContentColor.current,
+                )
             }
             actions()
         },
@@ -355,6 +366,7 @@ fun CollectionPage(
                     modifier = Modifier.fillMaxSize(),
                     enableAnimation = enableAnimation,
                     gridState = remember(pageIndex) { state.getGridState(pageIndex) },
+                    sortByName = sortByName,
                 )
             }
         }

--- a/app/shared/ui-subject/src/commonMain/kotlin/ui/subject/collection/SubjectCollectionsColumn.kt
+++ b/app/shared/ui-subject/src/commonMain/kotlin/ui/subject/collection/SubjectCollectionsColumn.kt
@@ -57,8 +57,6 @@ import androidx.compose.ui.unit.dp
 import androidx.paging.PagingData
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItemsWithLifecycle
-import androidx.paging.compose.itemContentType
-import androidx.paging.compose.itemKey
 import kotlinx.coroutines.flow.MutableStateFlow
 import me.him188.ani.app.data.models.subject.SubjectCollectionInfo
 import me.him188.ani.app.data.models.subject.TestSubjectCollections
@@ -97,10 +95,25 @@ fun SubjectCollectionsColumn(
     modifier: Modifier = Modifier,
     gridState: LazyGridState = rememberLazyGridState(),
     enableAnimation: Boolean = true,
+    sortByName: Boolean = false,
 ) {
     val isCompact = currentWindowAdaptiveInfo1().windowSizeClass.isWidthCompact
     val spacedBy = if (isCompact) 16.dp else 24.dp
     val aniMotionScheme = LocalAniMotionScheme.current
+
+    val orderedIndices: List<Int> = remember(sortByName, items.itemSnapshotList) {
+        if (!sortByName) {
+            (0 until items.itemCount).toList()
+        } else {
+            val snapshot = items.itemSnapshotList
+            val withKey = (0 until snapshot.size).mapNotNull { i ->
+                val info = snapshot[i]?.subjectInfo ?: return@mapNotNull null
+                val key = info.nameCn.ifEmpty { info.name }.lowercase()
+                i to key
+            }
+            withKey.sortedWith(compareBy({ it.second }, { it.first })).map { it.first }
+        }
+    }
 
     LazyVerticalGrid(
         GridCells.Adaptive(360.dp),
@@ -122,11 +135,20 @@ fun SubjectCollectionsColumn(
         }
 
         items(
-            items.itemCount,
-            items.itemKey { "SubjectCollectionsColumn-" + it.subjectId },
-            contentType = items.itemContentType { it.progressInfo.nextEpisodeIdToPlay != null },
-        ) { index ->
-            items[index]?.let {
+            orderedIndices.size,
+            key = { renderedIdx ->
+                val realIdx = orderedIndices[renderedIdx]
+                val info = items.peek(realIdx)
+                if (info != null) "SubjectCollectionsColumn-" + info.subjectId
+                else "SubjectCollectionsColumn-placeholder-$realIdx"
+            },
+            contentType = { renderedIdx ->
+                val realIdx = orderedIndices[renderedIdx]
+                items.peek(realIdx)?.progressInfo?.nextEpisodeIdToPlay != null
+            },
+        ) { renderedIdx ->
+            val realIdx = orderedIndices[renderedIdx]
+            items[realIdx]?.let {
                 Box(
                     Modifier
                         .padding(all = spacedBy / 2)

--- a/app/shared/ui-subject/src/commonMain/kotlin/ui/subject/collection/UserCollectionsViewModel.kt
+++ b/app/shared/ui-subject/src/commonMain/kotlin/ui/subject/collection/UserCollectionsViewModel.kt
@@ -133,4 +133,10 @@ class UserCollectionsViewModel : AbstractViewModel(), KoinComponent {
             collectionType.toggleCollected(),
         )
     }
+
+    suspend fun toggleSortByName() {
+        settingsRepository.uiSettings.update {
+            copy(myCollections = myCollections.copy(sortByName = !myCollections.sortByName))
+        }
+    }
 }


### PR DESCRIPTION
 ---
  Description

  Add a sort-by-name toggle to the Collection page. Tapping the icon in the top-app-bar reorders the list alphabetically by `nameCn` (fallback `name`, case-insensitive); tapping again restores the default `lastUpdated DESC` order. The preference persists in `MyCollectionsSettings`.

  Fixes #2989

  Reasoning

  Same client-side sort pattern as #2941. Sort runs purely in the UI layer on the loaded Paging snapshot — no DAO, no Room migration, no new queries. `orderedIndices` is wrapped in `remember(sortByName, items.itemSnapshotList)` so resort only happens on toggle or when Paging emits a new page; the sort key is precomputed once per item; the `sortByName == false` path is a no-op identity list.

  Known limitation: only loaded Paging items participate in the sort. When a new page loads, the newly-appended items are in server order and slot in on the next snapshot update. Same trade-off #2941 accepts.

  Testing

  1. Open **我的收藏**; tap the new sort icon in the top-app-bar
  2. List reorders alphabetically; icon takes primary tint
  3. Tap again; default order restores
  4. Switch tabs; state is shared across all 5 tabs
  5. Kill and reopen the app; preference persists
  6. Clear data; default is OFF (identical to pre-patch behavior)

  Type of change

  :x: Bug fix (A non-breaking change that fixes an issue)
  :white_check_mark: New feature (A non-breaking change that adds functionality)
  :x: Breaking change (A fix or feature that would cause existing functionality to not work as expected)
  :x: Refactor (A code change that neither fixes a bug nor adds a feature)
  :x: Performance (A code change that improves performance)
  :x: Style (Code style changes)
  :x: Docs (Changes to documentation)
  :x: Chore (Changes to the build process or other tooling)