### PR TITLE
feat(settings): 增加弹幕正则过滤规则导入导出并加入至设置备份

### DIFF
--- a/app/shared/app-data/src/commonMain/kotlin/data/repository/player/DanmakuRegexFilterRepository.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/repository/player/DanmakuRegexFilterRepository.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 OpenAni and contributors.
+ * Copyright (C) 2024-2026 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -20,6 +20,7 @@ interface DanmakuRegexFilterRepository {
     suspend fun update(id: String, new: DanmakuRegexFilter)
     suspend fun remove(filter: DanmakuRegexFilter)
     suspend fun add(new: DanmakuRegexFilter)
+    suspend fun replaceAll(new: List<DanmakuRegexFilter>)
 
 }
 
@@ -47,6 +48,10 @@ class DanmakuRegexFilterRepositoryImpl(
         store.updateData { data ->
             data + new
         }
+    }
+
+    override suspend fun replaceAll(new: List<DanmakuRegexFilter>) {
+        store.updateData { new }
     }
 
     companion object {

--- a/app/shared/app-data/src/commonMain/kotlin/data/repository/player/DanmakuRegexFilterRepository.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/repository/player/DanmakuRegexFilterRepository.kt
@@ -10,8 +10,14 @@
 package me.him188.ani.app.data.repository.player
 
 import androidx.datastore.core.DataStore
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.json.Json
 import me.him188.ani.app.data.models.danmaku.DanmakuRegexFilter
+import me.him188.ani.utils.coroutines.IO_
 
 interface DanmakuRegexFilterRepository {
 
@@ -21,12 +27,16 @@ interface DanmakuRegexFilterRepository {
     suspend fun remove(filter: DanmakuRegexFilter)
     suspend fun add(new: DanmakuRegexFilter)
     suspend fun replaceAll(new: List<DanmakuRegexFilter>)
+    suspend fun export(): String
+    suspend fun import(jsonString: String): Boolean
 
 }
 
 class DanmakuRegexFilterRepositoryImpl(
     private val store: DataStore<List<DanmakuRegexFilter>>,
 ) : DanmakuRegexFilterRepository {
+
+    private val json = Json { ignoreUnknownKeys = true }
 
     override val flow: Flow<List<DanmakuRegexFilter>> = store.data
 
@@ -52,6 +62,30 @@ class DanmakuRegexFilterRepositoryImpl(
 
     override suspend fun replaceAll(new: List<DanmakuRegexFilter>) {
         store.updateData { new }
+    }
+
+    override suspend fun export(): String {
+        return withContext(Dispatchers.IO_) {
+            json.encodeToString(
+                ListSerializer(DanmakuRegexFilter.serializer()),
+                store.data.first(),
+            )
+        }
+    }
+
+    override suspend fun import(jsonString: String): Boolean {
+        return withContext(Dispatchers.IO_) {
+            try {
+                val filters = json.decodeFromString(
+                    ListSerializer(DanmakuRegexFilter.serializer()),
+                    jsonString,
+                )
+                store.updateData { filters }
+                true
+            } catch (_: Exception) {
+                false
+            }
+        }
     }
 
     companion object {

--- a/app/shared/app-data/src/commonTest/kotlin/data/repository/player/DanmakuRegexFilterRepositoryTest.kt
+++ b/app/shared/app-data/src/commonTest/kotlin/data/repository/player/DanmakuRegexFilterRepositoryTest.kt
@@ -1,0 +1,210 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.data.repository.player
+
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import me.him188.ani.app.data.models.danmaku.DanmakuRegexFilter
+import me.him188.ani.app.data.persistent.MemoryDataStore
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class DanmakuRegexFilterRepositoryTest {
+    private fun createRepository(
+        initial: List<DanmakuRegexFilter> = emptyList(),
+    ): DanmakuRegexFilterRepositoryImpl {
+        return DanmakuRegexFilterRepositoryImpl(MemoryDataStore(initial))
+    }
+
+    private fun createFilter(
+        id: String = "1",
+        name: String = "",
+        regex: String = "test",
+        enabled: Boolean = true,
+    ) = DanmakuRegexFilter(id = id, name = name, regex = regex, enabled = enabled)
+
+    // add
+
+    @Test
+    fun `add appends filter`() = runTest {
+        val repo = createRepository()
+        val filter = createFilter()
+
+        repo.add(filter)
+
+        assertEquals(listOf(filter), repo.flow.first())
+    }
+
+    @Test
+    fun `add preserves existing filters`() = runTest {
+        val f1 = createFilter(id = "1", regex = "a")
+        val f2 = createFilter(id = "2", regex = "b")
+        val repo = createRepository(listOf(f1))
+
+        repo.add(f2)
+
+        assertEquals(listOf(f1, f2), repo.flow.first())
+    }
+
+    // remove
+
+    @Test
+    fun `remove deletes filter by identity`() = runTest {
+        val f1 = createFilter(id = "1", regex = "a")
+        val f2 = createFilter(id = "2", regex = "b")
+        val repo = createRepository(listOf(f1, f2))
+
+        repo.remove(f1)
+
+        assertEquals(listOf(f2), repo.flow.first())
+    }
+
+    // update
+
+    @Test
+    fun `update replaces filter with same id`() = runTest {
+        val f1 = createFilter(id = "1", regex = "a")
+        val repo = createRepository(listOf(f1))
+        val updated = createFilter(id = "1", regex = "updated")
+
+        repo.update("1", updated)
+
+        assertEquals(listOf(updated), repo.flow.first())
+    }
+
+    @Test
+    fun `update does nothing when id not found`() = runTest {
+        val f1 = createFilter(id = "1", regex = "a")
+        val repo = createRepository(listOf(f1))
+
+        repo.update("nonexistent", createFilter(id = "nonexistent"))
+
+        assertEquals(listOf(f1), repo.flow.first())
+    }
+
+    // replaceAll
+
+    @Test
+    fun `replaceAll clears and sets new filters`() = runTest {
+        val f1 = createFilter(id = "1", regex = "old1")
+        val f2 = createFilter(id = "2", regex = "old2")
+        val repo = createRepository(listOf(f1, f2))
+        val newList = listOf(createFilter(id = "3", regex = "new"))
+
+        repo.replaceAll(newList)
+
+        assertEquals(newList, repo.flow.first())
+    }
+
+    @Test
+    fun `replaceAll with empty list clears filters`() = runTest {
+        val f1 = createFilter(id = "1")
+        val repo = createRepository(listOf(f1))
+
+        repo.replaceAll(emptyList())
+
+        assertEquals(emptyList(), repo.flow.first())
+    }
+
+    // export
+
+    @Test
+    fun `export serializes filters to JSON`() = runTest {
+        val f1 = createFilter(id = "1", name = "", regex = "pattern1", enabled = true)
+        val f2 = createFilter(id = "2", name = "", regex = "pattern2", enabled = false)
+        val repo = createRepository(listOf(f1, f2))
+
+        val json = repo.export()
+
+        assertTrue(json.contains("\"id\":\"1\""))
+        assertTrue(json.contains("\"regex\":\"pattern1\""))
+        assertTrue(json.contains("\"enabled\":false"))
+    }
+
+    @Test
+    fun `export empty list produces empty JSON array`() = runTest {
+        val repo = createRepository()
+
+        val json = repo.export()
+
+        assertEquals("[]", json.trim())
+    }
+
+    // import
+
+    @Test
+    fun `import deserializes and replaces filters`() = runTest {
+        val oldFilter = createFilter(id = "old", regex = "old")
+        val repo = createRepository(listOf(oldFilter))
+        val json = """[{"id":"new","name":"","regex":"new","enabled":true}]"""
+
+        val result = repo.import(json)
+
+        assertTrue(result)
+        val filters = repo.flow.first()
+        assertEquals(1, filters.size)
+        assertEquals("new", filters[0].id)
+        assertEquals("new", filters[0].regex)
+    }
+
+    @Test
+    fun `import with invalid JSON returns false`() = runTest {
+        val repo = createRepository()
+
+        val result = repo.import("not valid json")
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun `import with valid JSON but wrong structure returns false`() = runTest {
+        val repo = createRepository()
+
+        val result = repo.import("""{"not":"a list"}""")
+
+        assertFalse(result)
+    }
+
+    // round-trip
+
+    @Test
+    fun `export then import preserves filters`() = runTest {
+        val f1 = createFilter(id = "1", name = "n1", regex = "r1", enabled = true)
+        val f2 = createFilter(id = "2", name = "n2", regex = "r2", enabled = false)
+        val repo = createRepository(listOf(f1, f2))
+
+        val json = repo.export()
+        // Create a fresh repository to simulate import on a different instance
+        val freshRepo = createRepository()
+        val result = freshRepo.import(json)
+
+        assertTrue(result)
+        val restored = freshRepo.flow.first()
+        assertEquals(2, restored.size)
+        assertEquals(f1, restored[0])
+        assertEquals(f2, restored[1])
+    }
+
+    @Test
+    fun `import does not leave old filters behind`() = runTest {
+        val f1 = createFilter(id = "1", regex = "keep")
+        val f2 = createFilter(id = "2", regex = "keep")
+        val repo = createRepository(listOf(f1, f2))
+
+        val json = """[{"id":"3","name":"","regex":"new","enabled":true}]"""
+        repo.import(json)
+
+        val filters = repo.flow.first()
+        assertEquals(1, filters.size)
+        assertEquals("3", filters[0].id)
+    }
+}

--- a/app/shared/app-lang/src/androidMain/res/values-zh-rCN/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values-zh-rCN/strings.xml
@@ -464,6 +464,12 @@
     <string name="settings_danmaku_regex_expression">正则表达式</string>
     <string name="settings_danmaku_regex_invalid">正则表达式语法不正确</string>
     <string name="settings_danmaku_regex_description">填写用于屏蔽的正则表达式，例如：\'.*签.*\' 会屏蔽所有含有文字\'签\'的弹幕。</string>
+    <string name="settings_danmaku_export_to_clipboard">复制规则到剪切板</string>
+    <string name="settings_danmaku_import_from_clipboard">从剪切板导入规则</string>
+    <string name="settings_danmaku_import_title">导入弹幕正则过滤规则</string>
+    <string name="settings_danmaku_import_description">这会覆盖当前创建的所有规则，且无法撤销，确认导入吗？</string>
+    <string name="settings_danmaku_import_failed">导入失败，剪切板内容无效</string>
+    <string name="settings_danmaku_import_success">导入成功</string>
 
     <!-- ConnectionTesterResultIndicator -->
     <string name="settings_framework_timeout">超时</string>

--- a/app/shared/app-lang/src/androidMain/res/values-zh-rHK/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values-zh-rHK/strings.xml
@@ -431,6 +431,12 @@
     <string name="settings_danmaku_regex_expression">正則表達式</string>
     <string name="settings_danmaku_regex_invalid">正則表達式語法不正確</string>
     <string name="settings_danmaku_regex_description">填寫用於屏蔽的正則表達式，例如：\'.*簽.*\' 會屏蔽所有含有文字\'簽\'的彈幕。</string>
+    <string name="settings_danmaku_export_to_clipboard">複製規則到剪貼板</string>
+    <string name="settings_danmaku_import_from_clipboard">從剪貼板導入規則</string>
+    <string name="settings_danmaku_import_title">導入彈幕正則過濾規則</string>
+    <string name="settings_danmaku_import_description">這會覆蓋當前創建的所有規則，且無法撤銷，確認導入嗎？</string>
+    <string name="settings_danmaku_import_failed">導入失敗，剪貼板內容無效</string>
+    <string name="settings_danmaku_import_success">導入成功</string>
 
     <!-- ConnectionTesterResultIndicator -->
     <string name="settings_framework_timeout">超時</string>

--- a/app/shared/app-lang/src/androidMain/res/values-zh-rTW/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values-zh-rTW/strings.xml
@@ -431,6 +431,12 @@
     <string name="settings_danmaku_regex_expression">正則表達式</string>
     <string name="settings_danmaku_regex_invalid">正則表達式語法不正確</string>
     <string name="settings_danmaku_regex_description">填寫用於屏蔽的正則表達式，例如：\'.*簽.*\' 會屏蔽所有含有文字\'簽\'的彈幕。</string>
+    <string name="settings_danmaku_export_to_clipboard">複製規則到剪貼板</string>
+    <string name="settings_danmaku_import_from_clipboard">從剪貼板導入規則</string>
+    <string name="settings_danmaku_import_title">導入彈幕正則過濾規則</string>
+    <string name="settings_danmaku_import_description">這會覆蓋當前創建的所有規則，且無法撤銷，確認導入嗎？</string>
+    <string name="settings_danmaku_import_failed">導入失敗，剪貼板內容無效</string>
+    <string name="settings_danmaku_import_success">導入成功</string>
 
     <!-- ConnectionTesterResultIndicator -->
     <string name="settings_framework_timeout">超時</string>

--- a/app/shared/app-lang/src/androidMain/res/values/strings.xml
+++ b/app/shared/app-lang/src/androidMain/res/values/strings.xml
@@ -426,6 +426,12 @@
     <string name="settings_danmaku_regex_expression">Regular Expression</string>
     <string name="settings_danmaku_regex_invalid">Invalid regular expression syntax</string>
     <string name="settings_danmaku_regex_description">Enter a regular expression for filtering, e.g.: \'.*sign.*\' will filter all danmaku containing the word \'sign\'.</string>
+    <string name="settings_danmaku_export_to_clipboard">Copy rules to clipboard</string>
+    <string name="settings_danmaku_import_from_clipboard">Import rules from clipboard</string>
+    <string name="settings_danmaku_import_title">Import danmaku regex filter rules</string>
+    <string name="settings_danmaku_import_description">Import danmaku regex filter rules from clipboard. This will overwrite all current rules and cannot be undone. Confirm import?</string>
+    <string name="settings_danmaku_import_failed">Import failed, clipboard content is invalid</string>
+    <string name="settings_danmaku_import_success">Import successful</string>
 
     <!-- ConnectionTesterResultIndicator -->
     <string name="settings_framework_timeout">Timeout</string>

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeViewModel.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeViewModel.kt
@@ -392,6 +392,8 @@ class EpisodeViewModel(
                 danmakuRegexFilterRepository.update(it.id, it.copy(enabled = !it.enabled))
             }
         },
+        onExport = { danmakuRegexFilterRepository.export() },
+        onImport = { danmakuRegexFilterRepository.import(it) },
     )
 
 

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/SettingsViewModel.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/SettingsViewModel.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-2025 OpenAni and contributors.
+ * Copyright (C) 2024-2026 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -23,6 +23,7 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import me.him188.ani.app.data.models.danmaku.DanmakuConfigSerializer
 import me.him188.ani.app.data.models.danmaku.DanmakuFilterConfig
+import me.him188.ani.app.data.models.danmaku.DanmakuRegexFilter
 import me.him188.ani.app.data.models.preference.AnalyticsSettings
 import me.him188.ani.app.data.models.preference.AnitorrentConfig
 import me.him188.ani.app.data.models.preference.PikPakConfig
@@ -364,6 +365,7 @@ class SettingsViewModel : AbstractSettingsViewModel(), KoinComponent {
             danmakuEnabled = settingsRepository.danmakuEnabled.flow.first(),
             danmakuConfig = settingsRepository.danmakuConfig.flow.first(),
             danmakuFilterConfig = settingsRepository.danmakuFilterConfig.flow.first(),
+            danmakuRegexFilters = danmakuRegexFilterRepository.flow.first(),
             mediaSelectorSettings = settingsRepository.mediaSelectorSettings.flow.first(),
             defaultMediaPreference = settingsRepository.defaultMediaPreference.flow.first(),
             profileSettings = settingsRepository.profileSettings.flow.first(),
@@ -398,6 +400,7 @@ class SettingsViewModel : AbstractSettingsViewModel(), KoinComponent {
         backup.danmakuEnabled?.let { settingsRepository.danmakuEnabled.set(it) }
         backup.danmakuConfig?.let { settingsRepository.danmakuConfig.set(it) }
         backup.danmakuFilterConfig?.let { settingsRepository.danmakuFilterConfig.set(it) }
+        backup.danmakuRegexFilters?.let { danmakuRegexFilterRepository.replaceAll(it) }
         backup.mediaSelectorSettings?.let { settingsRepository.mediaSelectorSettings.set(it) }
         backup.defaultMediaPreference?.let { settingsRepository.defaultMediaPreference.set(it) }
         backup.profileSettings?.let { settingsRepository.profileSettings.set(it) }
@@ -450,6 +453,7 @@ private data class SettingsBackup(
     val danmakuEnabled: Boolean?,
     @Serializable(with = DanmakuConfigSerializer::class) val danmakuConfig: DanmakuConfig?,
     val danmakuFilterConfig: DanmakuFilterConfig?,
+    val danmakuRegexFilters: List<DanmakuRegexFilter>? = null,
     val mediaSelectorSettings: MediaSelectorSettings?,
     val defaultMediaPreference: MediaPreference?,
     val profileSettings: ProfileSettings?,

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/SettingsViewModel.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/SettingsViewModel.kt
@@ -267,6 +267,8 @@ class SettingsViewModel : AbstractSettingsViewModel(), KoinComponent {
                 danmakuRegexFilterRepository.update(it.id, it.copy(enabled = !it.enabled))
             }
         },
+        onExport = { danmakuRegexFilterRepository.export() },
+        onImport = { danmakuRegexFilterRepository.import(it) },
     )
 
     val danmakuServerTesters = DefaultConnectionTesterRunner(

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/danmaku/DanmakuRegexFilterGroup.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/danmaku/DanmakuRegexFilterGroup.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-2025 OpenAni and contributors.
+ * Copyright (C) 2024-2026 OpenAni and contributors.
  *
  * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
  * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
@@ -20,6 +20,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Add
 import androidx.compose.material.icons.rounded.Close
+import androidx.compose.material.icons.rounded.ContentPaste
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ElevatedFilterChip
 import androidx.compose.material3.Icon
@@ -44,22 +45,34 @@ import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onKeyEvent
+import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow.Companion.Ellipsis
 import androidx.compose.ui.unit.dp
 import me.him188.ani.app.data.models.danmaku.DanmakuRegexFilter
+import me.him188.ani.app.ui.foundation.getClipEntryText
 import me.him188.ani.app.ui.foundation.ifThen
+import me.him188.ani.app.ui.foundation.rememberAsyncHandler
+import me.him188.ani.app.ui.foundation.setClipEntryText
+import me.him188.ani.app.ui.foundation.widgets.LocalToaster
 import me.him188.ani.app.ui.lang.Lang
 import me.him188.ani.app.ui.lang.settings_danmaku_add_regex
 import me.him188.ani.app.ui.lang.settings_danmaku_add_regex_filter
 import me.him188.ani.app.ui.lang.settings_danmaku_cancel
 import me.him188.ani.app.ui.lang.settings_danmaku_confirm
+import me.him188.ani.app.ui.lang.settings_danmaku_export_to_clipboard
+import me.him188.ani.app.ui.lang.settings_danmaku_import_description
+import me.him188.ani.app.ui.lang.settings_danmaku_import_failed
+import me.him188.ani.app.ui.lang.settings_danmaku_import_from_clipboard
+import me.him188.ani.app.ui.lang.settings_danmaku_import_success
+import me.him188.ani.app.ui.lang.settings_danmaku_import_title
 import me.him188.ani.app.ui.lang.settings_danmaku_regex_description
 import me.him188.ani.app.ui.lang.settings_danmaku_regex_expression
 import me.him188.ani.app.ui.lang.settings_danmaku_regex_filter_group
 import me.him188.ani.app.ui.lang.settings_danmaku_regex_invalid
+import me.him188.ani.app.ui.lang.settings_mediasource_rss_copied_to_clipboard
 import me.him188.ani.app.ui.settings.framework.components.SettingsScope
 import me.him188.ani.utils.platform.Uuid
 import org.jetbrains.compose.resources.stringResource
@@ -78,6 +91,7 @@ internal fun SettingsScope.DanmakuRegexFilterGroup(
     state: DanmakuRegexFilterState,
 ) {
     var showAdd by rememberSaveable { mutableStateOf(false) }
+    var showImportDialog by remember { mutableStateOf(false) }
 
     if (showAdd) {
         AddRegexFilterDialog(
@@ -86,6 +100,43 @@ internal fun SettingsScope.DanmakuRegexFilterGroup(
             },
             onAdd = state.add,
             title = { Text(stringResource(Lang.settings_danmaku_add_regex_filter)) },
+        )
+    }
+
+    val scope = rememberAsyncHandler()
+    val clipboard = LocalClipboard.current
+    val toaster = LocalToaster.current
+    val copiedToast = stringResource(Lang.settings_mediasource_rss_copied_to_clipboard)
+
+    if (showImportDialog) {
+        val importSuccess = stringResource(Lang.settings_danmaku_import_success)
+        val importFailed = stringResource(Lang.settings_danmaku_import_failed)
+
+        AlertDialog(
+            onDismissRequest = { showImportDialog = false },
+            icon = { Icon(Icons.Rounded.ContentPaste, null, tint = MaterialTheme.colorScheme.error) },
+            title = { Text(stringResource(Lang.settings_danmaku_import_title)) },
+            text = { Text(stringResource(Lang.settings_danmaku_import_description)) },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        scope.launch {
+                            val text = clipboard.getClipEntryText()
+                                ?.takeIf { it.isNotBlank() }
+                            val result = text?.let { state.onImport(it) } == true
+                            toaster.toast(if (result) importSuccess else importFailed)
+                            showImportDialog = false
+                        }
+                    },
+                ) {
+                    Text(stringResource(Lang.settings_danmaku_confirm), color = MaterialTheme.colorScheme.error)
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showImportDialog = false }) {
+                    Text(stringResource(Lang.settings_danmaku_cancel))
+                }
+            },
         )
     }
 
@@ -118,6 +169,26 @@ internal fun SettingsScope.DanmakuRegexFilterGroup(
                     onDelete = { state.remove(item) },
                     onDisable = { state.switch(item) },
                 )
+            }
+        }
+        Row(
+            Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 4.dp),
+            horizontalArrangement = Arrangement.End,
+        ) {
+            TextButton(
+                onClick = {
+                    scope.launch {
+                        val data = state.onExport()
+                        clipboard.setClipEntryText(data)
+                        toaster.toast(copiedToast)
+                    }
+                },
+            ) {
+                Text(stringResource(Lang.settings_danmaku_export_to_clipboard))
+            }
+
+            TextButton(onClick = { showImportDialog = true }) {
+                Text(stringResource(Lang.settings_danmaku_import_from_clipboard))
             }
         }
     }

--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/danmaku/DanmakuRegexFilterState.kt
+++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/settings/danmaku/DanmakuRegexFilterState.kt
@@ -1,3 +1,12 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
 package me.him188.ani.app.ui.settings.danmaku
 
 import androidx.compose.runtime.Stable
@@ -15,6 +24,8 @@ class DanmakuRegexFilterState(
     val edit: (id: String, new: DanmakuRegexFilter) -> Unit,
     val remove: (filter: DanmakuRegexFilter) -> Unit,
     val switch: (filter: DanmakuRegexFilter) -> Unit,
+    val onExport: suspend () -> String,
+    val onImport: suspend (String) -> Boolean,
 ) {
     val list by list
 }
@@ -58,6 +69,8 @@ fun createTestDanmakuRegexFilterState(): DanmakuRegexFilterState {
         edit = defaultEdit,
         remove = defaultRemove,
         switch = defaultSwitch,
+        onExport = { "[]" },
+        onImport = { true },
     )
 }
 


### PR DESCRIPTION
# 功能描述

### 弹幕正则过滤规则 - 剪贴板导出/导入

设置页面的"弹幕正则过滤器管理"下方新增两个按钮，逻辑参考了设置备份部分：

**1.复制规则到剪贴板**：将当前所有正则过滤规则序列化为 JSON 并复制到剪贴板

**2.从剪贴板导入规则**：点击后弹出确认对话框，确认后读取剪贴板 JSON 并替换全部现有规则

### 弹幕正则过滤规则纳入设置备份

SettingsBackup 新增 danmakuRegexFilters 字段（默认 null，兼容旧备份数据）。备份时自动写入当前所有正则规则，恢复时完整替换（非追加），确保备份还原后规则与导出时完全一致。

relates to #2767