### PR TITLE
Reorganized PRs 2/4: Hide dead web sources (#3025)

### DIFF
--- a/app/shared/app-data/src/commonMain/kotlin/data/models/preference/MediaSelectionSeetings.kt
+++ b/app/shared/app-data/src/commonMain/kotlin/data/models/preference/MediaSelectionSeetings.kt
@@ -55,6 +55,11 @@ constructor(
      */
     val fastSelectWebKind: Boolean = true,
     /**
+     * Hide currently failed web sources in the simple source selector.
+     * @since 4.2
+     */
+    val hideDeadWebSources: Boolean = false,
+    /**
      * 给 low tier 源加载的宽容时间, 在这个时间内只接受 low tier 加载完成, 
      * 就算 high tier 比 low tier 率先加载完成也不选择.
      * 超过这个时间就放开 tier 限制, 选择所有加载好的最低 tier 的源.

--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeViewModel.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeViewModel.kt
@@ -805,6 +805,7 @@ class EpisodeViewModel(
                         getPreferredWebMediaSource(subjectId),
                         backgroundScope,
                         webCaptchaCoordinator,
+                        settingsRepository.mediaSelectorSettings,
                     )
                 } else {
                     // TODO: 2025/1/22 We should not use createTestMediaSelectorState

--- a/app/shared/ui-mediaselect/src/commonMain/kotlin/ui/mediafetch/MediaSelectorState.kt
+++ b/app/shared/ui-mediaselect/src/commonMain/kotlin/ui/mediafetch/MediaSelectorState.kt
@@ -32,6 +32,8 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import me.him188.ani.app.data.models.preference.MediaPreference
 import me.him188.ani.app.data.models.preference.MediaSelectorSettings
+import me.him188.ani.app.data.repository.user.Settings
+import me.him188.ani.app.data.repository.user.SettingsRepository
 import me.him188.ani.app.domain.media.TestMediaList
 import me.him188.ani.app.domain.media.fetch.MediaSourceFetchResult
 import me.him188.ani.app.domain.media.fetch.MediaSourceFetchState
@@ -65,6 +67,7 @@ fun rememberMediaSelectorState(
 ): MediaSelectorState {
     val scope = rememberBackgroundScope()
     val webCaptchaCoordinator = remember { GlobalKoin.get<WebCaptchaCoordinator>() }
+    val settingsRepository = remember { GlobalKoin.get<SettingsRepository>() }
     val selector by remember {
         derivedStateOf(mediaSelector)
     }
@@ -76,6 +79,7 @@ fun rememberMediaSelectorState(
             flowOf(null),
             scope.backgroundScope,
             webCaptchaCoordinator,
+            settingsRepository.mediaSelectorSettings,
         )
     }
 }
@@ -146,6 +150,10 @@ class MediaSelectorState(
     private val preferredWebMediaSource: Flow<String?>,
     private val backgroundScope: CoroutineScope,
     private val webCaptchaCoordinator: WebCaptchaCoordinator,
+    private val mediaSelectorSettings: Settings<MediaSelectorSettings> = object : Settings<MediaSelectorSettings> {
+        override val flow: Flow<MediaSelectorSettings> = flowOf(MediaSelectorSettings.Default)
+        override suspend fun set(value: MediaSelectorSettings) = Unit
+    },
 ) {
     @Immutable
     data class Presentation(
@@ -162,6 +170,8 @@ class MediaSelectorState(
         val webSources: List<WebSource>,
         val selectedWebSource: WebSource?,
         val selectedWebSourceChannel: WebSourceChannel?,
+        val hideDeadWebSourcesEnabled: Boolean,
+        val hiddenDeadWebSourceCount: Int,
         val isPlaceholder: Boolean = false,
     )
 
@@ -192,8 +202,21 @@ class MediaSelectorState(
         subtitleLanguageId.presentationFlow,
         mediaSource.presentationFlow,
         createWebSourcesFlow(),
-    ) { filteredCandidatesMedia, preferredCandidates, selected, alliance, resolution, subtitleLanguageId, mediaSource, webSources ->
+        mediaSelectorSettings.flow.map { it.hideDeadWebSources },
+    ) { filteredCandidatesMedia, preferredCandidates, selected, alliance, resolution, subtitleLanguageId, mediaSource, webSources, hideDeadWebSourcesEnabled ->
         val (groupsExcluded, groupsIncluded) = MediaGrouper.buildGroups(preferredCandidates).partition { it.isExcluded }
+        val selectedWebSource = webSources.find { source -> source.channels.any { it.original == selected } }
+        val selectedWebSourceChannel = selectedWebSource?.channels?.find { it.original == selected }
+        val visibleWebSources = if (hideDeadWebSourcesEnabled) {
+            webSources.filterNot { it.shouldBeHiddenAsDeadSource(selected) }
+        } else {
+            webSources
+        }
+        val hiddenDeadWebSourceCount = if (hideDeadWebSourcesEnabled) {
+            webSources.count { it.shouldBeHiddenAsDeadSource(selected) }
+        } else {
+            0
+        }
         Presentation(
             filteredCandidatesMedia,
             preferredCandidates.mapNotNull { it.result },
@@ -201,9 +224,11 @@ class MediaSelectorState(
             groupsExcluded,
             selected,
             alliance, resolution, subtitleLanguageId, mediaSource,
-            webSources,
-            selectedWebSource = webSources.find { source -> source.channels.any { it.original == selected } },
-            selectedWebSourceChannel = webSources.firstNotNullOfOrNull { source -> source.channels.find { it.original == selected } },
+            visibleWebSources,
+            selectedWebSource = selectedWebSource,
+            selectedWebSourceChannel = selectedWebSourceChannel,
+            hideDeadWebSourcesEnabled = hideDeadWebSourcesEnabled,
+            hiddenDeadWebSourceCount = hiddenDeadWebSourceCount,
         )
     }.stateIn(
         backgroundScope,
@@ -217,6 +242,8 @@ class MediaSelectorState(
             webSources = emptyList(),
             selectedWebSource = null,
             selectedWebSourceChannel = null,
+            hideDeadWebSourcesEnabled = false,
+            hiddenDeadWebSourceCount = 0,
             isPlaceholder = true,
         ),
     )
@@ -363,6 +390,18 @@ class MediaSelectorState(
             resolvingCaptchaInstanceIds.value = resolvingCaptchaInstanceIds.value - source.instanceId
         }
     }
+
+    fun setHideDeadWebSourcesEnabled(enabled: Boolean) {
+        backgroundScope.launch {
+            mediaSelectorSettings.update {
+                copy(hideDeadWebSources = enabled)
+            }
+        }
+    }
+
+    private fun WebSource.shouldBeHiddenAsDeadSource(selected: Media?): Boolean {
+        return isError && channels.none { it.original == selected }
+    }
 }
 
 @Stable
@@ -398,4 +437,8 @@ fun createTestMediaSelectorState(backgroundScope: CoroutineScope) =
         preferredWebMediaSource = flowOf(null),
         backgroundScope,
         NoopWebCaptchaCoordinator,
+        object : Settings<MediaSelectorSettings> {
+            override val flow: Flow<MediaSelectorSettings> = flowOf(MediaSelectorSettings.Default)
+            override suspend fun set(value: MediaSelectorSettings) = Unit
+        },
     )

--- a/app/shared/ui-mediaselect/src/commonMain/kotlin/ui/mediafetch/MediaSelectorView.kt
+++ b/app/shared/ui-mediaselect/src/commonMain/kotlin/ui/mediafetch/MediaSelectorView.kt
@@ -175,7 +175,13 @@ fun MediaSelectorView(
                                 }
                             }
                         },
+                        onRefreshAll = onRefresh,
+                        hideDeadSourcesEnabled = presentation.hideDeadWebSourcesEnabled,
+                        onHideDeadSourcesEnabledChange = {
+                            state.setHideDeadWebSourcesEnabled(it)
+                        },
                         onRequestQueryEdit = { showEditRequest = true },
+                        hiddenDeadSourceCount = presentation.hiddenDeadWebSourceCount,
                         Modifier.padding(bottom = bottomPadding)
                             .weight(1f, fill = false)
                             .fillMaxWidth()

--- a/app/shared/ui-mediaselect/src/commonMain/kotlin/ui/mediaselect/selector/MediaSelectorWebColumn.kt
+++ b/app/shared/ui-mediaselect/src/commonMain/kotlin/ui/mediaselect/selector/MediaSelectorWebColumn.kt
@@ -30,6 +30,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.InputChip
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.minimumInteractiveComponentSize
@@ -45,6 +46,7 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.material3.IconButton as MaterialIconButton
 import me.him188.ani.app.domain.mediasource.instance.MediaSourceInstance
 import me.him188.ani.app.domain.mediasource.web.WebCaptchaRequest
 import me.him188.ani.app.ui.foundation.IconButton
@@ -97,7 +99,11 @@ fun MediaSelectorWebSourcesColumn(
     onSelect: (WebSource, WebSourceChannel) -> Unit,
     onRefresh: (WebSource) -> Unit,
     onResolveCaptcha: (WebSource) -> Unit,
+    onRefreshAll: () -> Unit,
+    hideDeadSourcesEnabled: Boolean,
+    onHideDeadSourcesEnabledChange: (Boolean) -> Unit,
     onRequestQueryEdit: () -> Unit,
+    hiddenDeadSourceCount: Int,
     modifier: Modifier = Modifier,
     preferredSourceContainerColor: Color = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.33f)
 ) {
@@ -130,6 +136,33 @@ fun MediaSelectorWebSourcesColumn(
 //    }
     Column(modifier, verticalArrangement = Arrangement.spacedBy(8.dp)) {
         // not scrollable. 否则会跟 bottom sheet 的 scroll 冲突. 
+        Row(
+            Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                "\u9690\u85CF\u65E0\u4FE1\u53F7\u6E90",
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            Switch(
+                checked = hideDeadSourcesEnabled,
+                onCheckedChange = onHideDeadSourcesEnabledChange,
+            )
+            MaterialIconButton(onClick = onRefreshAll) {
+                Icon(
+                    Icons.Rounded.Refresh,
+                    contentDescription = "\u91CD\u65B0\u6D4B\u8BD5\u6E90",
+                )
+            }
+            if (hideDeadSourcesEnabled && hiddenDeadSourceCount > 0) {
+                Text(
+                    "\u5DF2\u9690\u85CF $hiddenDeadSourceCount \u4E2A\u5931\u6548\u6E90",
+                    color = MaterialTheme.colorScheme.outline,
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            }
+        }
         list.forEach { source ->
             card(source)
         }
@@ -271,7 +304,11 @@ private fun PreviewMediaSelectorWebColumn() {
                 onSelect = { _, _ -> },
                 onRefresh = {},
                 onResolveCaptcha = {},
+                onRefreshAll = {},
+                hideDeadSourcesEnabled = false,
+                onHideDeadSourcesEnabledChange = {},
                 onRequestQueryEdit = {},
+                hiddenDeadSourceCount = 0,
             )
         }
     }
@@ -290,7 +327,11 @@ private fun PreviewMediaSelectorWebColumn3() {
                 onSelect = { _, _ -> },
                 onRefresh = {},
                 onResolveCaptcha = {},
+                onRefreshAll = {},
+                hideDeadSourcesEnabled = true,
+                onHideDeadSourcesEnabledChange = {},
                 onRequestQueryEdit = {},
+                hiddenDeadSourceCount = 1,
             )
         }
     }


### PR DESCRIPTION
Closes #3025.

## Summary
- add a toggle to hide failed web sources in media selector
- keep the currently selected failed source visible
- show hidden dead source count and add refresh-all entry
- persist the hide-dead-sources preference in media selector settings

## Validation
- `:app:shared:ui-mediaselect:desktopTest --tests "*MediaSelectorCaptchaStateTest"`
- `:app:shared:ui-mediaselect:compileKotlinDesktop`
- `:app:shared:compileKotlinDesktop`