### PR TITLE
Reorganized PRs 3/4: Add 2.5x & Custom playback speed (#3026)

### DIFF
--- a/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeVideo.kt
+++ b/app/shared/src/commonMain/kotlin/ui/subject/episode/EpisodeVideo.kt
@@ -121,8 +121,8 @@ import me.him188.ani.app.videoplayer.ui.progress.AudioSwitcher
 import me.him188.ani.app.videoplayer.ui.progress.MediaProgressIndicatorText
 import me.him188.ani.app.videoplayer.ui.progress.PlayerControllerBar
 import me.him188.ani.app.videoplayer.ui.progress.PlayerControllerDefaults
-import me.him188.ani.app.videoplayer.ui.progress.PlayerControllerDefaults.SpeedSwitcher
 import me.him188.ani.app.videoplayer.ui.progress.PlayerControllerDefaults.VideoAspectRatioSelector
+import me.him188.ani.app.videoplayer.ui.progress.PlaybackSpeedSwitcher
 import me.him188.ani.app.videoplayer.ui.progress.PlayerProgressSliderState
 import me.him188.ani.app.videoplayer.ui.progress.SubtitleSwitcher
 import me.him188.ani.app.videoplayer.ui.progress.rememberMediaProgressSliderState
@@ -446,7 +446,7 @@ internal fun EpisodeVideoImpl(
                             val playbackSpeedAlwaysOnRequester =
                                 rememberAlwaysOnRequester(playerControllerState, "speedSwitcher")
                             playbackSpeedControllerState?.also { controller ->
-                                SpeedSwitcher(controller) {
+                                PlaybackSpeedSwitcher(controller) {
                                     if (it) {
                                         playbackSpeedAlwaysOnRequester.request()
                                     } else {

--- a/app/shared/video-player/src/commonMain/kotlin/ui/PlaybackSpeedControllerState.kt
+++ b/app/shared/video-player/src/commonMain/kotlin/ui/PlaybackSpeedControllerState.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 import org.openani.mediamp.InternalForInheritanceMediampApi
 import org.openani.mediamp.features.PlaybackSpeed
+import kotlin.math.roundToInt
 
 /**
  * Side-effect: creation of this state will immediately set the playback speed to the initial speed.
@@ -31,28 +32,26 @@ import org.openani.mediamp.features.PlaybackSpeed
 @Stable
 class PlaybackSpeedControllerState(
     private val playbackSpeed: PlaybackSpeed,
-    speedProvider: () -> List<Float> = { listOf(0.5f, 0.75f, 1f, 1.25f, 1.5f, 1.75f, 2f, 3f) },
+    speedProvider: () -> List<Float> = { listOf(0.25f, 0.5f, 0.75f, 1f, 1.25f, 1.5f, 1.75f, 2f) },
     scope: CoroutineScope
 ) {
+    companion object {
+        const val MIN_CUSTOM_SPEED = 0.1f
+        const val MAX_CUSTOM_SPEED = 5.0f
+    }
+
     val speedList: List<Float> by derivedStateOf(speedProvider)
     var currentSpeed by mutableStateOf(playbackSpeed.value)
+        private set
+    var isCustomSpeedDialogVisible by mutableStateOf(false)
+        private set
+    var customSpeedInput by mutableStateOf(playbackSpeed.value.formatPlaybackSpeed())
         private set
 
     /**
      * `-1` represents a invalid index, which means the current speed is not in the list.
      */
-    val currentIndex: Int by derivedStateOf {
-        val index = speedList.indexOf(currentSpeed)
-        if (index == -1) {
-            speedList.indexOf(1f).also {
-                check(it != -1) {
-                    "Playback speed list must contain 1.0f, but was $speedList"
-                }
-            }
-        } else {
-            index
-        }
-    }
+    val currentIndex: Int by derivedStateOf { speedList.indexOf(currentSpeed) }
 
     init {
         require(speedList.isNotEmpty()) { "Playback speed list must not be empty" }
@@ -72,7 +71,12 @@ class PlaybackSpeedControllerState(
         scope.launch {
             playbackSpeed.valueFlow
                 .distinctUntilChanged()
-                .collect { value -> currentSpeed = value }
+                .collect { value ->
+                    currentSpeed = value
+                    if (!isCustomSpeedDialogVisible) {
+                        customSpeedInput = value.formatPlaybackSpeed()
+                    }
+                }
         }
     }
 
@@ -110,8 +114,36 @@ class PlaybackSpeedControllerState(
         playbackSpeed.set(value)
     }
 
+    fun setCustomSpeed(value: Float) {
+        val normalized = ((value * 10).roundToInt() / 10f)
+            .coerceIn(MIN_CUSTOM_SPEED, MAX_CUSTOM_SPEED)
+        setSpeed(normalized)
+    }
+
+    fun openCustomSpeedDialog() {
+        customSpeedInput = currentSpeed.formatPlaybackSpeed()
+        isCustomSpeedDialogVisible = true
+    }
+
+    fun closeCustomSpeedDialog() {
+        isCustomSpeedDialogVisible = false
+        customSpeedInput = currentSpeed.formatPlaybackSpeed()
+    }
+
+    fun updateCustomSpeedInput(value: String) {
+        customSpeedInput = value
+    }
+
     fun reset() {
         setSpeed(1f)
+    }
+}
+
+private fun Float.formatPlaybackSpeed(): String {
+    return if (this % 1f == 0f) {
+        roundToInt().toString()
+    } else {
+        toString().trimEnd('0').trimEnd('.')
     }
 }
 

--- a/app/shared/video-player/src/commonMain/kotlin/ui/progress/PlaybackSpeedSwitcher.kt
+++ b/app/shared/video-player/src/commonMain/kotlin/ui/progress/PlaybackSpeedSwitcher.kt
@@ -1,0 +1,177 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.app.videoplayer.ui.progress
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import me.him188.ani.app.ui.foundation.dialogs.PlatformPopupProperties
+import me.him188.ani.app.videoplayer.ui.PlaybackSpeedControllerState
+import kotlin.math.roundToInt
+
+@Composable
+fun PlaybackSpeedSwitcher(
+    playbackSpeedControllerState: PlaybackSpeedControllerState,
+    modifier: Modifier = Modifier,
+    onExpandedChanged: (expanded: Boolean) -> Unit = {},
+) {
+    Box(modifier, contentAlignment = Alignment.Center) {
+        var expanded by rememberSaveable { mutableStateOf(false) }
+        var openCustomDialogAfterDismiss by rememberSaveable { mutableStateOf(false) }
+        val currentSpeed = playbackSpeedControllerState.currentSpeed
+        val customSpeedInput = playbackSpeedControllerState.customSpeedInput
+        val showCustomDialog = playbackSpeedControllerState.isCustomSpeedDialogVisible
+        val isValidCustomSpeed = remember(customSpeedInput) {
+            customSpeedInput.parseCustomPlaybackSpeed() != null
+        }
+
+        LaunchedEffect(expanded, showCustomDialog) {
+            onExpandedChanged(expanded || showCustomDialog)
+        }
+
+        LaunchedEffect(expanded, openCustomDialogAfterDismiss, currentSpeed) {
+            if (!expanded && openCustomDialogAfterDismiss) {
+                playbackSpeedControllerState.openCustomSpeedDialog()
+                openCustomDialogAfterDismiss = false
+            }
+        }
+
+        TextButton(
+            onClick = { expanded = true },
+            colors = ButtonDefaults.textButtonColors(
+                contentColor = LocalContentColor.current,
+            ),
+            modifier = Modifier.testTag(TAG_SPEED_SWITCHER_TEXT_BUTTON),
+        ) {
+            Text("${currentSpeed.formatPlaybackSpeed()}x")
+        }
+
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+            properties = PlatformPopupProperties(
+                clippingEnabled = false,
+            ),
+            modifier = Modifier.testTag(TAG_SPEED_SWITCHER_DROPDOWN_MENU),
+        ) {
+            playbackSpeedControllerState.speedList.forEach { speedValue ->
+                DropdownMenuItem(
+                    text = {
+                        val color = if (currentSpeed == speedValue) {
+                            MaterialTheme.colorScheme.primary
+                        } else {
+                            LocalContentColor.current
+                        }
+                        CompositionLocalProvider(LocalContentColor provides color) {
+                            Text("${speedValue.formatPlaybackSpeed()}x")
+                        }
+                    },
+                    onClick = {
+                        expanded = false
+                        playbackSpeedControllerState.setSpeed(speedValue)
+                    },
+                )
+            }
+            DropdownMenuItem(
+                text = { Text("Custom") },
+                onClick = {
+                    openCustomDialogAfterDismiss = true
+                    expanded = false
+                },
+            )
+        }
+
+        if (showCustomDialog) {
+            AlertDialog(
+                onDismissRequest = { playbackSpeedControllerState.closeCustomSpeedDialog() },
+                title = { Text("Custom playback speed") },
+                text = {
+                    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                        OutlinedTextField(
+                            value = customSpeedInput,
+                            onValueChange = playbackSpeedControllerState::updateCustomSpeedInput,
+                            singleLine = true,
+                            label = { Text("Speed") },
+                            suffix = { Text("x") },
+                            isError = customSpeedInput.isNotBlank() && !isValidCustomSpeed,
+                            keyboardOptions = KeyboardOptions(
+                                keyboardType = KeyboardType.Decimal,
+                                imeAction = ImeAction.Done,
+                            ),
+                        )
+                        Text(
+                            "Enter a value from 0.1 to 5.0 with at most one decimal place.",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.outline,
+                        )
+                    }
+                },
+                confirmButton = {
+                    TextButton(
+                        enabled = isValidCustomSpeed,
+                        onClick = {
+                            customSpeedInput.parseCustomPlaybackSpeed()?.let {
+                                playbackSpeedControllerState.setCustomSpeed(it)
+                            }
+                            playbackSpeedControllerState.closeCustomSpeedDialog()
+                        },
+                    ) {
+                        Text("OK")
+                    }
+                },
+                dismissButton = {
+                    TextButton(onClick = { playbackSpeedControllerState.closeCustomSpeedDialog() }) {
+                        Text("Cancel")
+                    }
+                },
+            )
+        }
+    }
+}
+
+private fun Float.formatPlaybackSpeed(): String {
+    return if (this % 1f == 0f) {
+        roundToInt().toString()
+    } else {
+        toString().trimEnd('0').trimEnd('.')
+    }
+}
+
+private fun String.parseCustomPlaybackSpeed(): Float? {
+    val trimmed = trim()
+    if (!trimmed.matches(Regex("""\d+(\.\d)?"""))) return null
+    val value = trimmed.toFloatOrNull() ?: return null
+    return value.takeIf {
+        it in PlaybackSpeedControllerState.MIN_CUSTOM_SPEED..PlaybackSpeedControllerState.MAX_CUSTOM_SPEED
+    }
+}

--- a/app/shared/video-player/src/commonTest/kotlin/ui/PlaybackSpeedControllerStateTest.kt
+++ b/app/shared/video-player/src/commonTest/kotlin/ui/PlaybackSpeedControllerStateTest.kt
@@ -154,13 +154,13 @@ class PlaybackSpeedControllerStateTest {
         takeSnapshot()
         // 1.3f is not in list
         assertEquals(1.3f, state.currentSpeed)
-        assertEquals(1, state.currentIndex)
+        assertEquals(-1, state.currentIndex)
         
         state.speedUp()
         takeSnapshot()
         // nearestUp is 1.5f
-        assertEquals(1.25f, state.currentSpeed)
-        assertEquals(2, state.currentIndex)
+        assertEquals(1.5f, state.currentSpeed)
+        assertEquals(3, state.currentIndex)
     }
 
     @Test


### PR DESCRIPTION
Closes #3026.
Also covers #2780 and #2302.

## Summary
- add a dedicated playback speed switcher with a custom speed entry
- support custom playback speed input with validation and bounds
- fix state handling when current speed is not in the preset list
- update playback speed stepping behavior and related tests

## Validation
- `:app:shared:video-player:desktopTest --tests "*PlaybackSpeedControllerStateTest"`
- `:app:shared:video-player:compileKotlinDesktop`

## Notes
- `:app:shared:compileKotlinDesktop` was retried, but the rerun hit a Gradle/Kotlin daemon environment issue after module compilation had already progressed. The player-specific test and module compilation passed.
