### PR TITLE
[codex] Prefer Dandanplay Bangumi ID mapping

### DIFF
--- a/danmaku/dandanplay/build.gradle.kts
+++ b/danmaku/dandanplay/build.gradle.kts
@@ -32,6 +32,7 @@ kotlin {
     sourceSets.commonTest {
         dependencies {
             implementation(libs.kotlinx.coroutines.test)
+            implementation(libs.ktor.client.mock)
         }
     }
 }

--- a/danmaku/dandanplay/src/commonMain/kotlin/DandanplayClient.kt
+++ b/danmaku/dandanplay/src/commonMain/kotlin/DandanplayClient.kt
@@ -135,6 +135,21 @@ internal class DandanplayClient(
         }
     }
 
+    suspend fun getBangumiEpisodesByBgmtvSubjectId(
+        bgmtvSubjectId: Int,
+    ): DandanplayGetBangumiResponse = withContext(ioDispatcher) {
+        client.use {
+            val response =
+                get("https://api.dandanplay.net/api/v2/bangumi/bgmtv/$bgmtvSubjectId") {
+                    configureTimeout()
+                    accept(ContentType.Application.Json)
+                    addAuthorizationHeaders()
+                }
+
+            response.body<DandanplayGetBangumiResponse>()
+        }
+    }
+
     suspend fun matchVideo(
         filename: String,
         fileHash: String?,

--- a/danmaku/dandanplay/src/commonMain/kotlin/DandanplayDanmakuProvider.kt
+++ b/danmaku/dandanplay/src/commonMain/kotlin/DandanplayDanmakuProvider.kt
@@ -17,6 +17,7 @@ import me.him188.ani.danmaku.api.provider.DanmakuEpisode
 import me.him188.ani.danmaku.api.provider.DanmakuEpisodeWithSubject
 import me.him188.ani.danmaku.api.provider.DanmakuFetchRequest
 import me.him188.ani.danmaku.api.provider.DanmakuFetchResult
+import me.him188.ani.danmaku.api.provider.DanmakuMatcher
 import me.him188.ani.danmaku.api.provider.DanmakuMatchInfo
 import me.him188.ani.danmaku.api.provider.DanmakuMatchMethod
 import me.him188.ani.danmaku.api.provider.DanmakuMatchers
@@ -106,15 +107,30 @@ class DandanplayDanmakuProvider(
     private suspend fun fetchImpl(request: DanmakuFetchRequest): DanmakuFetchResult {
         // 获取剧集流程:
         //
-        // 1. 获取该番剧所属季度的所有番的名字, 匹配 bangumi 条目所有别名
-        // 2. 若失败, 用番剧名字搜索, 匹配 bangumi 条目所有别名
-        // 3. 如果按别名精准匹配到了, 那就获取该番的所有剧集
-        // 4. 如果没有, 那就提交条目名字给弹弹直接让弹弹获取相关剧集 (很不准)
+        // 1. 用 Bangumi subject id 请求弹弹 Play 的 Bangumi.tv 映射接口
+        // 2. 若失败, 获取该番剧所属季度的所有番的名字, 匹配 bangumi 条目所有别名
+        // 3. 若失败, 用番剧名字搜索, 匹配 bangumi 条目所有别名
+        // 4. 如果按别名精准匹配到了, 那就获取该番的所有剧集
+        // 5. 如果没有, 那就提交条目名字给弹弹直接让弹弹获取相关剧集 (很不准)
         //
         // 匹配剧集流程:
         // 1. 用剧集在系列中的序号 (sort) 匹配
         // 2. 用剧集在当前季度中的序号 (ep) 匹配
         // 3. 用剧集名字模糊匹配
+
+        val prefixedExpectedEpisodeName =
+            "第${(request.episodeEp ?: request.episodeSort).toString().removePrefix("0")}话 " + request.episodeName
+        val matcher = DanmakuMatchers.mostRelevant(
+            request.subjectPrimaryName,
+            prefixedExpectedEpisodeName,
+        )
+
+        val bgmtvEpisodes = runCatching { getEpisodesByBgmtvSubjectId(request) }
+            .onFailure {
+                if (it is CancellationException) throw it
+                logger.warn(it) { "Failed to fetch episodes by Bangumi subject id: ${request.subjectId}" }
+            }.getOrNull()
+        tryMatchEpisodes(request, bgmtvEpisodes, prefixedExpectedEpisodeName, matcher)?.let { return it }
 
         val episodes: List<DanmakuEpisodeWithSubject>? =
             runCatching { getEpisodesByExactSubjectMatch(request) }
@@ -128,51 +144,7 @@ class DandanplayDanmakuProvider(
                     if (it is CancellationException) throw it
                     logger.error(it) { "Failed to fetch episodes by fuzzy search" }
                 }.getOrNull()
-
-        val prefixedExpectedEpisodeName =
-            "第${(request.episodeEp ?: request.episodeSort).toString().removePrefix("0")}话 " + request.episodeName
-        val matcher = DanmakuMatchers.mostRelevant(
-            request.subjectPrimaryName,
-            prefixedExpectedEpisodeName,
-        )
-
-        // 用剧集编号匹配
-        // 先用系列的, 因为系列的更大
-        if (episodes != null) {
-            episodes.firstOrNull { it.epOrSort != null && it.epOrSort == request.episodeSort }?.let {
-                logger.info { "Matched episode by exact episodeSort: ${it.subjectName} - ${it.episodeName}" }
-                return createResult(it.id.toLong(), DanmakuMatchMethod.Exact(it.subjectName, it.episodeName))
-            }
-            episodes.firstOrNull { it.epOrSort != null && it.epOrSort == request.episodeEp }?.let {
-                logger.info { "Matched episode by exact episodeEp: ${it.subjectName} - ${it.episodeName}" }
-                return createResult(it.id.toLong(), DanmakuMatchMethod.Exact(it.subjectName, it.episodeName))
-            }
-
-            // 用名称精确匹配, 标记为 Exact
-            if (request.episodeName.isNotBlank()) {
-                val match =
-                    episodes.firstOrNull { it.episodeName == request.episodeName }
-                        ?: episodes.firstOrNull { it.episodeName == prefixedExpectedEpisodeName }
-                match?.let { episode ->
-                    logger.info { "Matched episode by exact episodeName: ${episode.subjectName} - ${episode.episodeName}" }
-                    return createResult(
-                        episode.id.toLong(),
-                        DanmakuMatchMethod.Exact(episode.subjectName, episode.episodeName),
-                    )
-                }
-            }
-        }
-
-        // 用名字不精确匹配
-        if (!episodes.isNullOrEmpty()) {
-            matcher.match(episodes)?.let {
-                logger.info { "Matched episode by ep search: ${it.subjectName} - ${it.episodeName}" }
-                return createResult(
-                    it.id.toLong(),
-                    DanmakuMatchMethod.ExactSubjectFuzzyEpisode(it.subjectName, it.episodeName),
-                )
-            }
-        }
+        tryMatchEpisodes(request, episodes, prefixedExpectedEpisodeName, matcher)?.let { return it }
 
         // 都不行, 那就用最不准的方法
 
@@ -209,9 +181,83 @@ class DandanplayDanmakuProvider(
         return DanmakuFetchResult.noMatch(providerId, DanmakuServiceId.Dandanplay)
     }
 
-    /**
-     * 用尝试用 bangumi 给的名字 `SubjectInfo.allNames` 去精准匹配
-     */
+    private suspend fun tryMatchEpisodes(
+        request: DanmakuFetchRequest,
+        episodes: List<DanmakuEpisodeWithSubject>?,
+        prefixedExpectedEpisodeName: String,
+        matcher: DanmakuMatcher,
+    ): DanmakuFetchResult? {
+        if (episodes == null) return null
+
+        // 用剧集编号匹配. 先用系列的, 因为系列的更大.
+        episodes.firstOrNull { it.epOrSort != null && it.epOrSort == request.episodeSort }?.let {
+            logger.info { "Matched episode by exact episodeSort: ${it.subjectName} - ${it.episodeName}" }
+            return createResult(it.id.toLong(), DanmakuMatchMethod.Exact(it.subjectName, it.episodeName))
+        }
+        episodes.firstOrNull { it.epOrSort != null && it.epOrSort == request.episodeEp }?.let {
+            logger.info { "Matched episode by exact episodeEp: ${it.subjectName} - ${it.episodeName}" }
+            return createResult(it.id.toLong(), DanmakuMatchMethod.Exact(it.subjectName, it.episodeName))
+        }
+
+        // 用名称精确匹配, 标记为 Exact.
+        if (request.episodeName.isNotBlank()) {
+            val match =
+                episodes.firstOrNull { it.episodeName == request.episodeName }
+                    ?: episodes.firstOrNull { it.episodeName == prefixedExpectedEpisodeName }
+            match?.let { episode ->
+                logger.info { "Matched episode by exact episodeName: ${episode.subjectName} - ${episode.episodeName}" }
+                return createResult(
+                    episode.id.toLong(),
+                    DanmakuMatchMethod.Exact(episode.subjectName, episode.episodeName),
+                )
+            }
+        }
+
+        // 用名字不精确匹配.
+        if (episodes.isNotEmpty()) {
+            matcher.match(episodes)?.let {
+                logger.info { "Matched episode by ep search: ${it.subjectName} - ${it.episodeName}" }
+                return createResult(
+                    it.id.toLong(),
+                    DanmakuMatchMethod.ExactSubjectFuzzyEpisode(it.subjectName, it.episodeName),
+                )
+            }
+        }
+
+        return null
+    }
+
+    private suspend fun getEpisodesByBgmtvSubjectId(
+        request: DanmakuFetchRequest
+    ): List<DanmakuEpisodeWithSubject>? {
+        if (request.subjectId <= 0) return null
+
+        val response = dandanplayClient.getBangumiEpisodesByBgmtvSubjectId(request.subjectId)
+        val bangumi = response.bangumi
+        if (!response.success || bangumi == null) {
+            logger.info {
+                "No Dandanplay Bangumi mapping found for Bangumi subject id: ${request.subjectId}, " +
+                        "errorCode=${response.errorCode}, errorMessage=${response.errorMessage}"
+            }
+            return null
+        }
+
+        val episodes = bangumi.episodes.orEmpty()
+        if (episodes.isEmpty()) return null
+
+        logger.info {
+            "Matched Dandanplay Bangumi by Bangumi subject id: ${request.subjectId} ${bangumi.animeTitle}"
+        }
+        return episodes.map { episode ->
+            DanmakuEpisodeWithSubject(
+                id = episode.episodeId.toString(),
+                subjectName = bangumi.animeTitle ?: request.subjectPrimaryName,
+                episodeName = episode.episodeTitle ?: "",
+                epOrSort = episode.episodeNumber?.let { EpisodeSort(it) },
+            )
+        }
+    }
+
     private suspend fun DandanplayDanmakuProvider.getEpisodesByExactSubjectMatch(
         request: DanmakuFetchRequest
     ): List<DanmakuEpisodeWithSubject>? {
@@ -220,11 +266,11 @@ class DandanplayDanmakuProvider(
         // 将筛选范围缩小到季度
         val anime = getDandanplayAnimeIdOrNull(request) ?: return null
         return dandanplayClient.getBangumiEpisodes(anime.bangumiId ?: anime.animeId)
-            .bangumi.episodes?.map { episode ->
+            .bangumi?.episodes?.map { episode ->
                 DanmakuEpisodeWithSubject(
                     id = episode.episodeId.toString(),
                     subjectName = request.subjectPrimaryName,
-                    episodeName = episode.episodeTitle,
+                    episodeName = episode.episodeTitle ?: "",
                     epOrSort = episode.episodeNumber?.let { EpisodeSort(it) },
                 )
             }
@@ -327,10 +373,10 @@ class DandanplayDanmakuProvider(
             val animeId = subject.id.toIntOrNull() ?: throw IllegalArgumentException("Invalid anime id: ${subject.id}")
             val bangumi = dandanplayClient.getBangumiEpisodes(animeId)
 
-            bangumi.bangumi.episodes?.map {
+            bangumi.bangumi?.episodes?.map {
                 DanmakuEpisode(
                     id = it.episodeId.toString(),
-                    name = it.episodeTitle,
+                    name = it.episodeTitle ?: "",
                 )
             } ?: emptyList()
         }

--- a/danmaku/dandanplay/src/commonMain/kotlin/data/DandanplayBangumi.kt
+++ b/danmaku/dandanplay/src/commonMain/kotlin/data/DandanplayBangumi.kt
@@ -97,8 +97,8 @@ data class DandanplayBangumiTitle(
  */
 @Serializable
 data class DandanplayBangumiEpisode(
-    val episodeId: Int,
-    val episodeTitle: String,
+    val episodeId: Long,
+    val episodeTitle: String? = null,
     val episodeNumber: String?,
     val lastWatched: String?,
     val airDate: String?

--- a/danmaku/dandanplay/src/commonMain/kotlin/data/MatchEpisode.kt
+++ b/danmaku/dandanplay/src/commonMain/kotlin/data/MatchEpisode.kt
@@ -35,7 +35,7 @@ data class DandanplaySearchEpisodeResponse(
 @Serializable
 data class DandanplayGetBangumiResponse(
     val hasMore: Boolean = false,
-    val bangumi: DandanplayBangumiDetails,
+    val bangumi: DandanplayBangumiDetails? = null,
     val errorCode: Int = 0,
     val success: Boolean = true,
     val errorMessage: String? = null,

--- a/danmaku/dandanplay/src/commonTest/kotlin/DandanplayDanmakuProviderTest.kt
+++ b/danmaku/dandanplay/src/commonTest/kotlin/DandanplayDanmakuProviderTest.kt
@@ -1,0 +1,201 @@
+/*
+ * Copyright (C) 2024-2026 OpenAni and contributors.
+ *
+ * 此源代码的使用受 GNU AFFERO GENERAL PUBLIC LICENSE version 3 许可证的约束, 可以在以下链接找到该许可证.
+ * Use of this source code is governed by the GNU AGPLv3 license, which can be found at the following link.
+ *
+ * https://github.com/open-ani/ani/blob/main/LICENSE
+ */
+
+package me.him188.ani.danmaku.dandanplay
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.MockRequestHandleScope
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.HttpResponseData
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import me.him188.ani.danmaku.api.provider.DanmakuFetchRequest
+import me.him188.ani.danmaku.api.provider.DanmakuMatchMethod
+import me.him188.ani.datasources.api.EpisodeSort
+import me.him188.ani.datasources.api.PackedDate
+import me.him188.ani.utils.ktor.asScopedHttpClient
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.time.Duration.Companion.minutes
+
+class DandanplayDanmakuProviderTest {
+    @Test
+    fun `fetchAutomatic uses Bangumi subject id mapping before existing matching`() = runTest {
+        val seenPaths = mutableListOf<String>()
+        val provider = createProvider { path ->
+            seenPaths += path
+            when (path) {
+                "/api/v2/bangumi/bgmtv/113906" -> respondJson(
+                    """
+                    {
+                      "success": true,
+                      "errorCode": 0,
+                      "errorMessage": "",
+                      "bangumi": {
+                        "animeTitle": "网球优等生 第二期",
+                        "type": "tvseries",
+                        "episodes": [
+                          {
+                            "episodeId": 108470001,
+                            "episodeTitle": "第1话 世界与鸿沟",
+                            "episodeNumber": "1",
+                            "lastWatched": null,
+                            "airDate": "2015-04-05T00:00:00"
+                          }
+                        ]
+                      }
+                    }
+                    """.trimIndent(),
+                )
+
+                "/api/v2/comment/108470001" -> respondJson("""{"count":0,"comments":[]}""")
+                else -> error("Unexpected request: $path")
+            }
+        }
+
+        val result = provider.fetchAutomatic(
+            request(
+                subjectId = 113906,
+                subjectName = "ベイビーステップ 第2シリーズ",
+                episodeSort = EpisodeSort(1),
+                episodeName = "世界と壁",
+            ),
+        ).single()
+
+        val method = assertIs<DanmakuMatchMethod.Exact>(result.matchInfo.method)
+        assertEquals("网球优等生 第二期", method.subjectTitle)
+        assertEquals("第1话 世界与鸿沟", method.episodeTitle)
+        assertEquals(
+            listOf(
+                "/api/v2/bangumi/bgmtv/113906",
+                "/api/v2/comment/108470001",
+            ),
+            seenPaths,
+        )
+    }
+
+    @Test
+    fun `fetchAutomatic falls back to existing matching when Bangumi subject id mapping is missing`() = runTest {
+        val seenPaths = mutableListOf<String>()
+        val provider = createProvider { path ->
+            seenPaths += path
+            when (path) {
+                "/api/v2/bangumi/bgmtv/999999999" -> respondJson(
+                    """
+                    {
+                      "success": false,
+                      "errorCode": 7,
+                      "errorMessage": "无法找到指定的资源",
+                      "bangumi": null
+                    }
+                    """.trimIndent(),
+                )
+
+                "/api/v2/search/episodes" -> respondJson(
+                    """
+                    {
+                      "success": true,
+                      "errorCode": 0,
+                      "errorMessage": "",
+                      "hasMore": false,
+                      "animes": [
+                        {
+                          "animeId": 1,
+                          "animeTitle": "fallback subject",
+                          "episodes": [
+                            {
+                              "episodeId": 123456,
+                              "episodeTitle": "fallback episode",
+                              "episodeNumber": "1"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                    """.trimIndent(),
+                )
+
+                "/api/v2/comment/123456" -> respondJson("""{"count":0,"comments":[]}""")
+                else -> error("Unexpected request: $path")
+            }
+        }
+
+        val result = provider.fetchAutomatic(
+            request(
+                subjectId = 999999999,
+                subjectName = "fallback subject",
+                episodeSort = EpisodeSort(1),
+                episodeName = "fallback episode",
+            ),
+        ).single()
+
+        val method = assertIs<DanmakuMatchMethod.Exact>(result.matchInfo.method)
+        assertEquals("fallback subject", method.subjectTitle)
+        assertEquals("fallback episode", method.episodeTitle)
+        assertEquals(
+            listOf(
+                "/api/v2/bangumi/bgmtv/999999999",
+                "/api/v2/search/episodes",
+                "/api/v2/comment/123456",
+            ),
+            seenPaths,
+        )
+    }
+
+    private fun createProvider(handler: MockRequestHandleScope.(path: String) -> HttpResponseData): DandanplayDanmakuProvider {
+        val engine = MockEngine { request ->
+            assertEquals("app-id", request.headers["X-AppId"])
+            handler(request.url.encodedPath)
+        }
+        val client = HttpClient(engine) {
+            install(ContentNegotiation) {
+                json(Json { ignoreUnknownKeys = true })
+            }
+        }
+        return DandanplayDanmakuProvider(
+            dandanplayAppId = "app-id",
+            dandanplayAppSecret = "app-secret",
+            client = client.asScopedHttpClient(),
+        )
+    }
+
+    private fun MockRequestHandleScope.respondJson(content: String) = respond(
+        content = content,
+        status = HttpStatusCode.OK,
+        headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+    )
+
+    private fun request(
+        subjectId: Int,
+        subjectName: String,
+        episodeSort: EpisodeSort,
+        episodeName: String,
+    ) = DanmakuFetchRequest(
+        subjectId = subjectId,
+        subjectPrimaryName = subjectName,
+        subjectNames = listOf(subjectName),
+        subjectPublishDate = PackedDate.Invalid,
+        episodeId = 1,
+        episodeSort = episodeSort,
+        episodeEp = null,
+        episodeName = episodeName,
+        filename = null,
+        fileHash = null,
+        fileSize = null,
+        videoDuration = 24.minutes,
+    )
+}


### PR DESCRIPTION
```
2026-05-22 13:02:44,702 [INFO ] HttpClientProvider:   GET https://api.dandanplay.net/api/v2/bangumi/bgmtv/531159 : 200 OK in 626.406916ms
2026-05-22 13:02:44,708 [INFO ] DandanplayDanmakuProvider: Matched Dandanplay Bangumi by Bangumi subject id: 531159 时光流逝，饭菜依旧美味
2026-05-22 13:02:44,709 [INFO ] DandanplayDanmakuProvider: Matched episode by exact episodeSort: 时光流逝，饭菜依旧美味 - 第11话 你们圣诞节有空吗？
```


## Summary

- Add Dandanplay `/api/v2/bangumi/bgmtv/{id}` client support and try it before the existing name-based matching path.
- Keep the old season/name/search matching as fallback when the Bangumi.tv mapping is missing or unusable.
- Update the local response schema for nullable `bangumi` / `episodeTitle` and int64 Dandanplay episode ids.
- Add provider tests for the preferred bgmtv path and fallback path.

## Validation

- `./gradlew :danmaku:dandanplay:desktopTest :danmaku:dandanplay:compileKotlinMetadata`

## Notes

The Dandanplay endpoint still requires the existing app signature headers. Live probes returned mapped data for known Bangumi subject ids and `success=false,errorCode=7,bangumi=null` for a missing mapping.
